### PR TITLE
feat: rpc and mcp specific message parsing

### DIFF
--- a/lib/hermes/message.ex
+++ b/lib/hermes/message.ex
@@ -1,0 +1,222 @@
+defmodule Hermes.Message do
+  @moduledoc """
+  Handles parsing and validation of MCP (Model Context Protocol) messages using the Peri library.
+
+  This module provides functions to parse and validate MCP messages based on the Model Context Protocol schema
+  """
+
+  import Peri
+
+  # MCP message schemas
+
+  @request_methods ~w(initialize ping resources/list resources/read prompts/get prompts/list tools/call tools/list)
+
+  @init_params_schema %{
+    "protocolVersion" => {:required, :string},
+    "capabilities" => {:required, :map},
+    "clientInfo" => %{
+      "name" => {:required, :string},
+      "version" => {:required, :string}
+    }
+  }
+
+  @ping_params_schema :map
+
+  @resources_list_params_schema %{
+    "cursor" => :string
+  }
+
+  @resources_read_params_schema %{
+    "uri" => {:required, :string}
+  }
+
+  @prompts_list_params_schema %{
+    "cursor" => :string
+  }
+
+  @prompts_get_params_schema %{
+    "name" => {:required, :string},
+    "arguments" => :map
+  }
+
+  @tools_list_params_schema %{
+    "cursor" => :string
+  }
+
+  @tools_call_params_schema %{
+    "name" => {:required, :string},
+    "arguments" => :map
+  }
+
+  defschema :request_schema, %{
+    "jsonrpc" => {:required, {:string, {:eq, "2.0"}}},
+    "method" => {:required, {:enum, @request_methods}},
+    "params" => {:dependent, &parse_request_params_by_method/1},
+    "id" => {:required, {:either, {:string, :integer}}}
+  }
+
+  defp parse_request_params_by_method(%{"method" => "initialize"}), do: {:ok, @init_params_schema}
+  defp parse_request_params_by_method(%{"method" => "ping"}), do: {:ok, @ping_params_schema}
+
+  defp parse_request_params_by_method(%{"method" => "resources/list"}),
+    do: {:ok, @resources_list_params_schema}
+
+  defp parse_request_params_by_method(%{"method" => "resources/read"}),
+    do: {:ok, @resources_read_params_schema}
+
+  defp parse_request_params_by_method(%{"method" => "prompts/list"}),
+    do: {:ok, @prompts_list_params_schema}
+
+  defp parse_request_params_by_method(%{"method" => "prompts/get"}),
+    do: {:ok, @prompts_get_params_schema}
+
+  defp parse_request_params_by_method(%{"method" => "tools/list"}),
+    do: {:ok, @tools_list_params_schema}
+
+  defp parse_request_params_by_method(%{"method" => "tools/call"}),
+    do: {:ok, @tools_call_params_schema}
+
+  defp parse_request_params_by_method(_), do: {:ok, :map}
+
+  @init_noti_params_schema :map
+  @cancel_noti_params_schema %{
+    "requestId" => {:required, {:either, {:string, :integer}}},
+    "reason" => :string
+  }
+  @progress_notif_params_schema %{
+    "progressToken" => {:required, {:either, {:string, :integer}}},
+    "progress" => {:required, :float},
+    "total" => :float
+  }
+
+  defschema :notification_schema, %{
+    "jsonrpc" => {:required, {:string, {:eq, "2.0"}}},
+    "method" =>
+      {:required,
+       {:enum, ~w(notifications/initialize notifications/cancelled notifications/progress)}},
+    "params" => {:dependent, &parse_notification_params_by_method/1}
+  }
+
+  defp parse_notification_params_by_method(%{"method" => "notifications/initialize"}),
+    do: {:ok, @init_noti_params_schema}
+
+  defp parse_notification_params_by_method(%{"method" => "notifications/cancelled"}),
+    do: {:ok, @cancel_noti_params_schema}
+
+  defp parse_notification_params_by_method(%{"method" => "notifications/progress"}),
+    do: {:ok, @progress_notif_params_schema}
+
+  defp parse_notification_params_by_method(_), do: {:ok, :map}
+
+  defschema :response_schema, %{
+    "jsonrpc" => {:required, {:string, {:eq, "2.0"}}},
+    "result" => {:required, :map},
+    "id" => {:required, {:either, {:string, :integer}}}
+  }
+
+  defschema :error_schema, %{
+    "jsonrpc" => {:required, {:string, {:eq, "2.0"}}},
+    "error" => %{
+      "code" => {:required, :integer},
+      "message" => {:required, :string},
+      "data" => :any
+    },
+    "id" => {:required, {:either, {:string, :integer}}}
+  }
+
+  defschema :mcp_message_schema,
+            {:oneof,
+             [
+               get_schema(:request_schema),
+               get_schema(:notification_schema),
+               get_schema(:response_schema),
+               get_schema(:error_schema)
+             ]}
+
+  @doc """
+  Determines if a JSON-RPC message is a request.
+  """
+  defguard is_request(data) when is_map_key(data, "method") and is_map_key(data, "id")
+
+  @doc """
+  Determines if a JSON-RPC message is a notification.
+  """
+  defguard is_notification(data) when is_map_key(data, "method") and not is_map_key(data, "id")
+
+  @doc """
+  Determines if a JSON-RPC message is a response.
+  """
+  defguard is_response(data) when is_map_key(data, "result") and is_map_key(data, "id")
+
+  @doc """
+  Determines if a JSON-RPC message is an error.
+  """
+  defguard is_error(data) when is_map_key(data, "error") and is_map_key(data, "id")
+
+  @doc """
+  Decodes raw data (possibly containing multiple messages) into JSON-RPC messages.
+
+  Returns either:
+  - `{:ok, messages}` where messages is a list of parsed JSON-RPC messages
+  - `{:error, reason}` if parsing fails
+  """
+  def decode(data) when is_binary(data) do
+    data
+    |> String.split("\n", trim: true)
+    |> Enum.reduce_while({:ok, []}, &parse_message/2)
+    |> then(fn
+      {:ok, messages} -> {:ok, Enum.reverse(messages)}
+      {:error, reason} -> {:error, reason}
+    end)
+  end
+
+  defp parse_message(line, {:ok, acc}) do
+    with {:ok, message} <- JSON.decode(line),
+         {:ok, message} <- validate_message(message) do
+      {:cont, {:ok, [message | acc]}}
+    else
+      err -> {:halt, err}
+    end
+  end
+
+  @doc """
+  Validates a decoded JSON message to ensure it complies with the MCP schema.
+  """
+  def validate_message(message) when is_map(message) do
+    with {:error, _} <- mcp_message_schema(message) do
+      {:error, :invalid_message}
+    end
+  end
+
+  @doc """
+  Encodes a request message to a JSON-RPC 2.0 compliant string.
+
+  Returns the encoded string with a newline character appended.
+  """
+  def encode_request(request, id) do
+    schema = get_schema(:request_schema)
+
+    request
+    |> Map.put("jsonrpc", "2.0")
+    |> Map.put("id", id)
+    |> encode_message(schema)
+  end
+
+  @doc """
+  Encodes a notification message to a JSON-RPC 2.0 compliant string.
+
+  Returns the encoded string with a newline character appended.
+  """
+  def encode_notification(notification) do
+    schema = get_schema(:notification_schema)
+
+    notification
+    |> Map.put("jsonrpc", "2.0")
+    |> encode_message(schema)
+  end
+
+  defp encode_message(data, schema) do
+    encoder = {schema, {:transform, fn data -> JSON.encode!(data) <> "\n" end}}
+    Peri.validate(encoder, data)
+  end
+end

--- a/test/hermes/message_test.exs
+++ b/test/hermes/message_test.exs
@@ -1,0 +1,287 @@
+defmodule Hermes.MessageTest do
+  use ExUnit.Case, async: true
+
+  alias Hermes.Message
+  require Hermes.Message
+
+  describe "decode/1" do
+    test "decodes a single valid message" do
+      json = ~s({"jsonrpc":"2.0","method":"ping","id":1}\n)
+
+      assert {:ok, [decoded]} = Message.decode(json)
+      assert decoded["jsonrpc"] == "2.0"
+      assert decoded["method"] == "ping"
+      assert decoded["id"] == 1
+    end
+
+    test "decodes multiple messages" do
+      json =
+        ~s({"jsonrpc":"2.0","method":"ping","id":1}\n{"jsonrpc":"2.0","method":"notifications/initialize"}\n)
+
+      assert {:ok, [msg1, msg2]} = Message.decode(json)
+      assert msg1["method"] == "ping"
+      assert msg2["method"] == "notifications/initialize"
+    end
+
+    test "returns error for invalid JSON" do
+      json = ~s({"jsonrpc":"2.0","method":broken}\n)
+
+      assert {:error, _} = Message.decode(json)
+    end
+
+    test "returns error for non-compliant message" do
+      json = ~s({"method":"unknown_method","id":1}\n)
+
+      assert {:error, :invalid_message} = Message.decode(json)
+    end
+  end
+
+  describe "validate_message/1" do
+    test "validates initialize request" do
+      msg = %{
+        "jsonrpc" => "2.0",
+        "method" => "initialize",
+        "id" => 1,
+        "params" => %{
+          "protocolVersion" => "2024-05-01",
+          "capabilities" => %{"foo" => "bar"},
+          "clientInfo" => %{
+            "name" => "TestClient",
+            "version" => "1.0.0"
+          }
+        }
+      }
+
+      assert {:ok, _} = Message.validate_message(msg)
+    end
+
+    test "validates ping request" do
+      msg = %{
+        "jsonrpc" => "2.0",
+        "method" => "ping",
+        "id" => 1
+      }
+
+      assert {:ok, _} = Message.validate_message(msg)
+    end
+
+    test "validates resources/list request" do
+      msg = %{
+        "jsonrpc" => "2.0",
+        "method" => "resources/list",
+        "id" => 1,
+        "params" => %{
+          "cursor" => "next-page"
+        }
+      }
+
+      assert {:ok, _} = Message.validate_message(msg)
+    end
+
+    test "validates resources/read request" do
+      msg = %{
+        "jsonrpc" => "2.0",
+        "method" => "resources/read",
+        "id" => 1,
+        "params" => %{
+          "uri" => "file:///path/to/file.txt"
+        }
+      }
+
+      assert {:ok, _} = Message.validate_message(msg)
+    end
+
+    test "validates notification message" do
+      msg = %{
+        "jsonrpc" => "2.0",
+        "method" => "notifications/initialize"
+      }
+
+      assert {:ok, _} = Message.validate_message(msg)
+    end
+
+    test "validates cancelled notification" do
+      msg = %{
+        "jsonrpc" => "2.0",
+        "method" => "notifications/cancelled",
+        "params" => %{
+          "requestId" => 123,
+          "reason" => "User cancelled"
+        }
+      }
+
+      assert {:ok, _} = Message.validate_message(msg)
+    end
+
+    test "validates response message" do
+      msg = %{
+        "jsonrpc" => "2.0",
+        "result" => %{"status" => "success"},
+        "id" => 1
+      }
+
+      assert {:ok, _} = Message.validate_message(msg)
+    end
+
+    test "validates error message" do
+      msg = %{
+        "jsonrpc" => "2.0",
+        "error" => %{
+          "code" => -32_600,
+          "message" => "Invalid Request"
+        },
+        "id" => 1
+      }
+
+      assert {:ok, _} = Message.validate_message(msg)
+    end
+
+    test "rejects message with invalid method" do
+      msg = %{
+        "jsonrpc" => "2.0",
+        "method" => "unknown_method",
+        "id" => 1
+      }
+
+      assert {:error, :invalid_message} = Message.validate_message(msg)
+    end
+
+    test "rejects message with missing required fields" do
+      # Missing protocolVersion in initialize params
+      msg = %{
+        "jsonrpc" => "2.0",
+        "method" => "initialize",
+        "id" => 1,
+        "params" => %{
+          "clientInfo" => %{
+            "name" => "TestClient",
+            "version" => "1.0.0"
+          }
+        }
+      }
+
+      assert {:error, :invalid_message} = Message.validate_message(msg)
+    end
+  end
+
+  describe "encode_request/2" do
+    test "encodes initialize request" do
+      req = %{
+        "method" => "initialize",
+        "params" => %{
+          "protocolVersion" => "2024-05-01",
+          "capabilities" => %{"foo" => "bar"},
+          "clientInfo" => %{
+            "name" => "TestClient",
+            "version" => "1.0.0"
+          }
+        }
+      }
+
+      assert {:ok, encoded} = Message.encode_request(req, 1)
+      assert is_binary(encoded)
+      assert String.ends_with?(encoded, "\n")
+
+      # Decode to validate
+      {:ok, [decoded]} = Message.decode(encoded)
+      assert decoded["id"] == 1
+      assert decoded["method"] == "initialize"
+    end
+
+    test "encodes ping request" do
+      req = %{"method" => "ping"}
+
+      assert {:ok, encoded} = Message.encode_request(req, "req-123")
+      assert is_binary(encoded)
+
+      # Decode to validate
+      {:ok, [decoded]} = Message.decode(encoded)
+      assert decoded["id"] == "req-123"
+      assert decoded["method"] == "ping"
+    end
+
+    test "returns error for invalid request" do
+      req = %{"method" => "unknown_method"}
+
+      assert {:error, _} = Message.encode_request(req, 1)
+    end
+  end
+
+  describe "encode_notification/1" do
+    test "encodes initialize notification" do
+      notif = %{"method" => "notifications/initialize"}
+
+      assert {:ok, encoded} = Message.encode_notification(notif)
+      assert is_binary(encoded)
+      assert String.ends_with?(encoded, "\n")
+
+      # Decode to validate
+      {:ok, [decoded]} = Message.decode(encoded)
+      assert decoded["method"] == "notifications/initialize"
+      refute Map.has_key?(decoded, "id")
+    end
+
+    test "encodes cancelled notification" do
+      notif = %{
+        "method" => "notifications/cancelled",
+        "params" => %{
+          "requestId" => 123,
+          "reason" => "User cancelled"
+        }
+      }
+
+      assert {:ok, encoded} = Message.encode_notification(notif)
+      assert is_binary(encoded)
+
+      # Decode to validate
+      {:ok, [decoded]} = Message.decode(encoded)
+      assert decoded["method"] == "notifications/cancelled"
+      assert decoded["params"]["requestId"] == 123
+    end
+
+    test "returns error for invalid notification" do
+      notif = %{"method" => "unknown_method"}
+
+      assert {:error, _} = Message.encode_notification(notif)
+    end
+  end
+
+  describe "guards" do
+    test "is_request/1 correctly identifies request messages" do
+      request = %{"jsonrpc" => "2.0", "method" => "ping", "id" => 1}
+      not_request = %{"jsonrpc" => "2.0", "method" => "notifications/initialize"}
+
+      assert Message.is_request(request)
+      refute Message.is_request(not_request)
+    end
+
+    test "is_notification/1 correctly identifies notification messages" do
+      notification = %{"jsonrpc" => "2.0", "method" => "notifications/initialize"}
+      not_notification = %{"jsonrpc" => "2.0", "method" => "ping", "id" => 1}
+
+      assert Message.is_notification(notification)
+      refute Message.is_notification(not_notification)
+    end
+
+    test "is_response/1 correctly identifies response messages" do
+      response = %{"jsonrpc" => "2.0", "result" => %{}, "id" => 1}
+      not_response = %{"jsonrpc" => "2.0", "method" => "ping", "id" => 1}
+
+      assert Message.is_response(response)
+      refute Message.is_response(not_response)
+    end
+
+    test "is_error/1 correctly identifies error messages" do
+      error = %{
+        "jsonrpc" => "2.0",
+        "error" => %{"code" => -32_600, "message" => "Invalid Request"},
+        "id" => 1
+      }
+
+      not_error = %{"jsonrpc" => "2.0", "result" => %{}, "id" => 1}
+
+      assert Message.is_error(error)
+      refute Message.is_error(not_error)
+    end
+  end
+end


### PR DESCRIPTION
## Problem
We needed a robust way to validate and process Model Context Protocol (MCP) messages according to the schema specification.

## Solution

This PR introduces the `Hermes.Message` module that:
- Defines specialized schemas for MCP protocol message validation
- Provides encoding/decoding functions for JSON-RPC messages
- Implements validation for all standard MCP message types (requests, notifications, responses, errors)
- Adds a comprehensive test suite to ensure proper handling of all message formats

## Rationale

1. **Schema Definition Approach**: We defined schemas for each message type and their parameters separately to allow for precise validation of the different MCP request and notification types.

2. **Dependent Validation**: Implemented smart parameter validation that changes based on the message method using Peri's dependent field support.

This implementation provides a clean, maintainable way to handle MCP protocol messages while ensuring strict adherence to the protocol specification.
