### PR TITLE
feat: allow sse graceful shutdown and handle sse streaming reconnection

### DIFF
--- a/lib/hermes/client.ex
+++ b/lib/hermes/client.ex
@@ -268,7 +268,8 @@ defmodule Hermes.Client do
     {:reply, state.server_info, state}
   end
 
-  def handle_call(:close, _from, %{transport: transport, pending_requests: pending} = state) do
+  @impl true
+  def handle_cast(:close, %{transport: transport, pending_requests: pending} = state) do
     if map_size(pending) > 0 do
       Logger.warning("Closing client with #{map_size(pending)} pending requests")
     end

--- a/lib/hermes/transport/sse.ex
+++ b/lib/hermes/transport/sse.ex
@@ -46,7 +46,7 @@ defmodule Hermes.Transport.SSE do
           | Supervisor.init_option()
 
   defschema :options_schema, %{
-    name: {:required, :atom},
+    name: {:atom, {:default, __MODULE__}},
     client: {:required, {:either, {:pid, :atom}}},
     server: [
       base_url: {:required, {:string, {:transform, &URI.new!/1}}},


### PR DESCRIPTION
# Problem

The Hermes MCP client was experiencing "Invalid session ID" errors when SSE connections were terminated unexpectedly or when attempting to shut down connections. This occurred because:

1. The SSE connection didn't properly handle reconnection when connections dropped
2. The client closure mechanism blocked when trying to close connections
3. Default timeouts were causing premature termination of long-lived SSE connections

These issues were documented in repo issues #11 and #22 related to graceful shutdown of SSE connections.

# Solution

The implementation includes several key improvements:

1. Modified the client closure mechanism from a synchronous `handle_call(:close)` to an asynchronous `handle_cast(:close)` to prevent blocking
2. Added automatic reconnection logic with the new `loop_sse_stream` function that recursively maintains the connection
3. Implemented proper infinite timeouts (`receive_timeout: :infinity, request_timeout: :infinity`) for SSE connections
4. Enhanced logging throughout the connection lifecycle for better diagnostics
5. Improved error handling in the SSE stream processing to handle various connection states
6. Changed function naming from `process_stream` to `process_task_stream` for clarity

# Rationale

SSE connections are designed to remain open indefinitely, making them susceptible to network interruptions and timeout issues. The recursive reconnection approach implemented in `loop_sse_stream` creates a self-healing connection that can recover from most failure scenarios.

The shift to asynchronous handling for connection closure prevents potential deadlocks during shutdown, particularly important when multiple pending requests might exist. This aligns better with Elixir's concurrency model.

Setting explicit infinite timeouts addresses the underlying cause of many premature disconnections, while the enhanced logging provides visibility into connection state changes that were previously difficult to diagnose.

These changes together create a more resilient SSE transport layer that can maintain stable connections and shut down gracefully when needed.
