### PR TITLE
Add support for registry-based names in client + http transport

### DIFF
--- a/lib/hermes.ex
+++ b/lib/hermes.ex
@@ -5,5 +5,16 @@ defmodule Hermes do
     Application.get_env(:hermes_mcp, :env, :dev)
   end
 
-  def dev_env?, do: env() == :dev
+  def dev_env? do
+    if env = Application.get_env(:hermes_mcp, :env) do
+      env == :dev
+    else
+      false
+    end
+  end
+
+  def genserver_name({:via, registry, _}) when is_atom(registry), do: :ok
+  def genserver_name(name) when is_atom(name), do: :ok
+  def genserver_name(pid) when is_pid(pid), do: :ok
+  def genserver_name(val), do: {:error, "#{val} is not a valid name for a GenServer"}
 end

--- a/lib/hermes/http.ex
+++ b/lib/hermes/http.ex
@@ -11,6 +11,7 @@ defmodule Hermes.HTTP do
 
   def build(method, url, headers \\ %{}, body \\ nil, opts \\ []) do
     with {:ok, uri} <- parse_uri(url) do
+      headers = Map.merge(@default_headers, headers)
       Finch.build(method, uri, Map.to_list(headers), body, opts)
     end
   end

--- a/lib/mix/tasks/sse.interactive.ex
+++ b/lib/mix/tasks/sse.interactive.ex
@@ -56,9 +56,7 @@ defmodule Mix.Tasks.Hermes.Sse.Interactive do
           "version" => "1.0.0"
         },
         capabilities: %{
-          "roots" => %{
-            "listChanged" => true
-          },
+          "tools" => %{},
           "sampling" => %{}
         }
       )

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -44,6 +44,8 @@ defmodule StubClient do
     {:reply, :ok, []}
   end
 
+  def handle_cast(msg, messages), do: handle_info(msg, messages)
+
   def handle_info(:initialize, messages), do: {:noreply, messages}
 
   def handle_info({:response, data}, messages) do


### PR DESCRIPTION
## Problem

We have a usecase that will have a number of mcp clients that is not knowable at compile time, which makes the static config this library is largely built around with its naming validation not as usable.

## Solution

Introduced a custom validator for the full genserver name spec (as i remember it) and wires it in the transport and client.

## Rationale

see above