### PR TITLE
feat: centralized state management

### DIFF
--- a/lib/hermes/client.ex
+++ b/lib/hermes/client.ex
@@ -28,8 +28,8 @@ defmodule Hermes.Client do
 
   import Peri
 
+  alias Hermes.Client.State
   alias Hermes.MCP.Error
-  alias Hermes.MCP.ID
   alias Hermes.MCP.Message
   alias Hermes.MCP.Response
 
@@ -307,8 +307,8 @@ defmodule Hermes.Client do
     * `callback` - The callback function to unregister
   """
   @spec unregister_log_callback(GenServer.server(), log_callback()) :: :ok
-  def unregister_log_callback(client, callback) when is_function(callback, 3) do
-    GenServer.call(client, {:unregister_log_callback, callback})
+  def unregister_log_callback(client, _callback) do
+    GenServer.call(client, :unregister_log_callback)
   end
 
   @doc """
@@ -379,19 +379,14 @@ defmodule Hermes.Client do
 
     transport = %{layer: layer, name: name}
 
-    state = %{
-      transport: transport,
-      client_info: opts.client_info,
-      capabilities: opts.capabilities,
-      server_capabilities: nil,
-      server_info: nil,
-      protocol_version: opts.protocol_version,
-      request_timeout: opts.request_timeout,
-      pending_requests: Map.new(),
-      progress_callbacks: Map.new(),
-      log_level: nil,
-      log_callback: nil
-    }
+    state =
+      State.new(%{
+        client_info: opts.client_info,
+        capabilities: opts.capabilities,
+        protocol_version: opts.protocol_version,
+        request_timeout: opts.request_timeout,
+        transport: transport
+      })
 
     Logger.metadata(mcp_client: opts.name, mcp_transport: opts.transport)
 
@@ -400,65 +395,61 @@ defmodule Hermes.Client do
 
   @impl true
   def handle_call({:request, method, params}, from, state) do
-    request_id = generate_request_id()
-
-    with :ok <- validate_capability(state, method),
+    with :ok <- State.validate_capability(state, method),
+         {request_id, updated_state} = State.add_request(state, method, params, from),
          {:ok, request_data} <- encode_request(method, params, request_id),
          :ok <- send_to_transport(state.transport, request_data) do
-      pending = Map.put(state.pending_requests, request_id, {from, method})
-
-      {:noreply, %{state | pending_requests: pending}}
+      {:noreply, updated_state}
     else
-      err -> {:reply, err, state}
+      {:error, _reason} = err -> {:reply, err, state}
     end
   end
 
   def handle_call({:request, method, params, progress_opts}, from, state) do
-    request_id = generate_request_id()
     state = maybe_register_progress_callback(state, progress_opts)
     params = maybe_add_progress_token(params, progress_opts)
 
-    with :ok <- validate_capability(state, method),
+    with :ok <- State.validate_capability(state, method),
+         {request_id, updated_state} = State.add_request(state, method, params, from),
          {:ok, request_data} <- encode_request(method, params, request_id),
          :ok <- send_to_transport(state.transport, request_data) do
-      pending = Map.put(state.pending_requests, request_id, {from, method})
-
-      {:noreply, %{state | pending_requests: pending}}
+      {:noreply, updated_state}
     else
-      err -> {:reply, err, state}
+      {:error, _reason} = err -> {:reply, err, state}
     end
   end
 
   def handle_call({:merge_capabilities, additional_capabilities}, _from, state) do
-    updated_capabilities = deep_merge(state.capabilities, additional_capabilities)
-
-    {:reply, updated_capabilities, %{state | capabilities: updated_capabilities}}
+    updated_state = State.merge_capabilities(state, additional_capabilities)
+    {:reply, updated_state.capabilities, updated_state}
   end
 
   def handle_call(:get_server_capabilities, _from, state) do
-    {:reply, state.server_capabilities, state}
+    {:reply, State.get_server_capabilities(state), state}
   end
 
   def handle_call(:get_server_info, _from, state) do
-    {:reply, state.server_info, state}
+    {:reply, State.get_server_info(state), state}
   end
 
   def handle_call({:register_log_callback, callback}, _from, state) do
-    {:reply, :ok, %{state | log_callback: callback}}
+    updated_state = State.set_log_callback(state, callback)
+    {:reply, :ok, updated_state}
   end
 
-  def handle_call({:unregister_log_callback, _callback}, _from, state) do
-    {:reply, :ok, %{state | log_callback: nil}}
+  def handle_call(:unregister_log_callback, _from, state) do
+    updated_state = State.clear_log_callback(state)
+    {:reply, :ok, updated_state}
   end
 
   def handle_call({:register_progress_callback, token, callback}, _from, state) do
-    progress_callbacks = Map.put(state.progress_callbacks, token, callback)
-    {:reply, :ok, %{state | progress_callbacks: progress_callbacks}}
+    updated_state = State.register_progress_callback(state, token, callback)
+    {:reply, :ok, updated_state}
   end
 
   def handle_call({:unregister_progress_callback, token}, _from, state) do
-    progress_callbacks = Map.delete(state.progress_callbacks, token)
-    {:reply, :ok, %{state | progress_callbacks: progress_callbacks}}
+    updated_state = State.unregister_progress_callback(state, token)
+    {:reply, :ok, updated_state}
   end
 
   def handle_call({:send_progress, progress_token, progress, total}, _from, state) do
@@ -471,19 +462,21 @@ defmodule Hermes.Client do
   end
 
   @impl true
-  def handle_cast(:close, %{transport: transport, pending_requests: pending} = state) do
-    if map_size(pending) > 0 do
-      Logger.warning("Closing client with #{map_size(pending)} pending requests")
+  def handle_cast(:close, state) do
+    pending_requests = State.list_pending_requests(state)
+
+    if length(pending_requests) > 0 do
+      Logger.warning("Closing client with #{length(pending_requests)} pending requests")
     end
 
-    for {request_id, _} <- pending do
+    for request <- pending_requests do
       send_notification(state, "notifications/cancelled", %{
-        "requestId" => request_id,
+        "requestId" => request.id,
         "reason" => "client closed"
       })
     end
 
-    transport.layer.shutdown(transport.name)
+    state.transport.layer.shutdown(state.transport.name)
 
     {:stop, :normal, state}
   end
@@ -498,14 +491,11 @@ defmodule Hermes.Client do
       "clientInfo" => state.client_info
     }
 
-    request_id = generate_request_id()
+    {request_id, updated_state} = State.add_request(state, "initialize", params, {self(), make_ref()})
 
     with {:ok, request_data} <- encode_request("initialize", params, request_id),
          :ok <- send_to_transport(state.transport, request_data) do
-      from = {self(), generate_request_id()}
-      pending = Map.put(state.pending_requests, request_id, {from, "initialize"})
-
-      {:noreply, %{state | pending_requests: pending}}
+      {:noreply, updated_state}
     else
       err -> {:stop, err, state}
     end
@@ -516,15 +506,28 @@ defmodule Hermes.Client do
       {:stop, :unexpected, state}
   end
 
+  def handle_info({:request_timeout, request_id}, state) do
+    case State.handle_request_timeout(state, request_id) do
+      {nil, state} ->
+        {:noreply, state}
+
+      {request_info, updated_state} ->
+        error = Error.client_error(:request_timeout, %{message: "Request timed out after #{request_info.elapsed_ms}ms"})
+        GenServer.reply(request_info.from, {:error, error})
+
+        {:noreply, updated_state}
+    end
+  end
+
   def handle_info({:response, response_data}, state) do
     case Message.decode(response_data) do
       {:ok, [error]} when Message.is_error(error) ->
         Logger.debug("Received server error response: #{inspect(error)}")
-        {:noreply, handle_error(error, error["id"], state)}
+        {:noreply, handle_error_response(error, error["id"], state)}
 
       {:ok, [response]} when Message.is_response(response) ->
         Logger.debug("Received server response: #{response["id"]}")
-        {:noreply, handle_response(response, response["id"], state)}
+        {:noreply, handle_success_response(response, response["id"], state)}
 
       {:ok, [notification]} when Message.is_notification(notification) ->
         method = notification["method"]
@@ -544,59 +547,74 @@ defmodule Hermes.Client do
 
   # Response handling
 
-  defp handle_error(%{"error" => json_error, "id" => id}, id, state) do
-    {{from, _method}, pending} = Map.pop(state.pending_requests, id)
+  defp handle_error_response(%{"error" => json_error, "id" => id}, id, state) do
+    case State.remove_request(state, id) do
+      {nil, state} ->
+        Logger.warning("Received error response for unknown request ID: #{id}")
+        state
 
-    # Convert JSON-RPC error to our domain error
-    error = Error.from_json_rpc(json_error)
+      {request_info, updated_state} ->
+        # Convert JSON-RPC error to our domain error
+        error = Error.from_json_rpc(json_error)
 
-    # unblocks original caller
-    GenServer.reply(from, {:error, error})
+        # Unblock original caller with error
+        GenServer.reply(request_info.from, {:error, error})
 
-    %{state | pending_requests: pending}
-  end
-
-  defp handle_error(response, _, state) do
-    Logger.warning("Received error response for unknown request ID: #{response["id"]}")
-    state
-  end
-
-  defp handle_response(%{"id" => id, "result" => %{"serverInfo" => _} = result}, id, state) do
-    %{pending_requests: pending} = state
-
-    state = %{
-      state
-      | server_capabilities: result["capabilities"],
-        server_info: result["serverInfo"],
-        pending_requests: Map.delete(pending, id)
-    }
-
-    Logger.info("Initialized successfully, notifing server")
-
-    # we need to confirm to the server the handshake
-    :ok = send_notification(state, "notifications/initialized")
-
-    state
-  end
-
-  defp handle_response(%{"id" => id, "result" => result}, id, state) do
-    {{from, method}, pending} = Map.pop(state.pending_requests, id)
-
-    # Convert to our domain response
-    response = Response.from_json_rpc(%{"result" => result, "id" => id})
-
-    # unblocks original caller
-    cond do
-      method == "ping" -> GenServer.reply(from, :pong)
-      Response.error?(response) -> GenServer.reply(from, {:error, response.result})
-      true -> GenServer.reply(from, {:ok, response.result})
+        updated_state
     end
-
-    %{state | pending_requests: pending}
   end
 
-  defp handle_response(%{"id" => _} = response, _, state) do
-    Logger.warning("Received response for unknown request ID: #{response["id"]}")
+  defp handle_error_response(%{"id" => id}, _id, state) do
+    Logger.warning("Received malformed error response for request ID: #{id}")
+    state
+  end
+
+  defp handle_success_response(%{"id" => id, "result" => %{"serverInfo" => _} = result}, id, state) do
+    case State.remove_request(state, id) do
+      {nil, state} ->
+        state
+
+      {_request_info, updated_state} ->
+        # Update server info in state
+        updated_state =
+          State.update_server_info(
+            updated_state,
+            result["capabilities"],
+            result["serverInfo"]
+          )
+
+        Logger.info("Initialized successfully, notifying server")
+
+        # Confirm to the server the handshake is complete
+        :ok = send_notification(updated_state, "notifications/initialized")
+
+        updated_state
+    end
+  end
+
+  defp handle_success_response(%{"id" => id, "result" => result}, id, state) do
+    case State.remove_request(state, id) do
+      {nil, state} ->
+        Logger.warning("Received response for unknown request ID: #{id}")
+        state
+
+      {request_info, updated_state} ->
+        # Convert to our domain response
+        response = Response.from_json_rpc(%{"result" => result, "id" => id})
+
+        # Unblock original caller with result
+        cond do
+          request_info.method == "ping" -> GenServer.reply(request_info.from, :pong)
+          Response.error?(response) -> GenServer.reply(request_info.from, {:error, response.result})
+          true -> GenServer.reply(request_info.from, {:ok, response.result})
+        end
+
+        updated_state
+    end
+  end
+
+  defp handle_success_response(%{"id" => id}, _id, state) do
+    Logger.warning("Received malformed response for request ID: #{id}")
     state
   end
 
@@ -617,7 +635,7 @@ defmodule Hermes.Client do
     progress = params["progress"]
     total = Map.get(params, "total")
 
-    if callback = Map.get(state.progress_callbacks, progress_token) do
+    if callback = State.get_progress_callback(state, progress_token) do
       # Execute the callback in a separate process to avoid blocking
       Task.start(fn -> callback.(progress_token, progress, total) end)
     end
@@ -631,7 +649,7 @@ defmodule Hermes.Client do
     logger = Map.get(params, "logger")
 
     # Execute callback if registered
-    if callback = state.log_callback do
+    if callback = State.get_log_callback(state) do
       Task.start(fn -> callback.(level, data, logger) end)
     end
 
@@ -668,8 +686,7 @@ defmodule Hermes.Client do
     with {:ok, opts} when not is_nil(opts) <- {:ok, progress_opts},
          {:ok, callback} when is_function(callback, 3) <- {:ok, Keyword.get(opts, :callback)},
          {:ok, token} when not is_nil(token) <- {:ok, Keyword.get(opts, :token)} do
-      progress_callbacks = Map.put(state.progress_callbacks, token, callback)
-      %{state | progress_callbacks: progress_callbacks}
+      State.register_progress_callback(state, token, callback)
     else
       _ -> state
     end
@@ -687,38 +704,6 @@ defmodule Hermes.Client do
   end
 
   # Helper functions
-
-  defp validate_capability(%{server_capabilities: nil}, _method) do
-    {:error, :server_capabilities_not_set}
-  end
-
-  defp validate_capability(%{server_capabilities: server_capabilities}, method) do
-    capability = String.split(method, "/", parts: 2)
-
-    if valid_capability?(server_capabilities, capability) do
-      :ok
-    else
-      {:error, {:capability_not_supported, method}}
-    end
-  end
-
-  defp valid_capability?(_capabilities, ["initialize"]), do: true
-  defp valid_capability?(_capabilities, ["ping"]), do: true
-
-  defp valid_capability?(capabilities, ["resources", sub]) when sub in ~w(subscribe unsubscribe) do
-    if resources = Map.get(capabilities, "resources") do
-      valid_capability?(resources, [sub, nil])
-    end
-  end
-
-  defp valid_capability?(%{} = capabilities, [capability, _]) do
-    Map.has_key?(capabilities, capability)
-  end
-
-  defp generate_request_id do
-    ID.generate_request_id()
-  end
-
   defp encode_request(method, params, request_id) do
     Message.encode_request(%{"method" => method, "params" => params}, request_id)
   end
@@ -737,12 +722,5 @@ defmodule Hermes.Client do
     with {:ok, notification_data} <- encode_notification(method, params) do
       send_to_transport(state.transport, notification_data)
     end
-  end
-
-  defp deep_merge(map1, map2) do
-    Map.merge(map1, map2, fn
-      _, v1, v2 when is_map(v1) and is_map(v2) -> deep_merge(v1, v2)
-      _, _, v2 -> v2
-    end)
   end
 end

--- a/lib/hermes/client/state.ex
+++ b/lib/hermes/client/state.ex
@@ -1,0 +1,501 @@
+defmodule Hermes.Client.State do
+  @moduledoc """
+  Manages state for the Hermes MCP client.
+
+  This module provides a structured representation of client state,
+  including capabilities, server info, and request tracking.
+
+  ## State Structure
+
+  Each client state includes:
+  - `client_info`: Information about the client
+  - `capabilities`: Client capabilities
+  - `server_capabilities`: Server capabilities received during initialization
+  - `server_info`: Server information received during initialization
+  - `protocol_version`: MCP protocol version being used
+  - `request_timeout`: Default timeout for requests
+  - `transport`: Transport module or transport info
+  - `pending_requests`: Map of pending requests with details and timers
+  - `progress_callbacks`: Map of callbacks for progress tracking
+  - `log_callback`: Callback for handling log messages
+
+  ## Examples
+
+  ```elixir
+  # Create a new client state
+  state = Hermes.Client.State.new(%{
+    client_info: %{"name" => "MyClient", "version" => "1.0.0"},
+    capabilities: %{"resources" => %{}},
+    protocol_version: "2024-11-05",
+    request_timeout: 30000,
+    transport: %{layer: Hermes.Transport.SSE, name: MyTransport}
+  })
+
+  # Add a request to the state
+  {request_id, updated_state} = Hermes.Client.State.add_request(state, "ping", %{}, from)
+
+  # Get server capabilities
+  server_capabilities = Hermes.Client.State.get_server_capabilities(state)
+  ```
+  """
+
+  alias Hermes.MCP.ID
+
+  @type progress_callback :: (String.t() | integer(), number(), number() | nil -> any())
+  @type log_callback :: (String.t(), term(), String.t() | nil -> any())
+
+  @type pending_request :: {GenServer.from(), String.t(), reference(), integer()}
+
+  @type t :: %__MODULE__{
+          client_info: map(),
+          capabilities: map(),
+          server_capabilities: map() | nil,
+          server_info: map() | nil,
+          protocol_version: String.t(),
+          request_timeout: integer(),
+          transport: map(),
+          pending_requests: %{String.t() => pending_request()},
+          progress_callbacks: %{String.t() => progress_callback()},
+          log_callback: log_callback() | nil
+        }
+
+  defstruct [
+    :client_info,
+    :capabilities,
+    :server_capabilities,
+    :server_info,
+    :protocol_version,
+    :request_timeout,
+    :transport,
+    pending_requests: %{},
+    progress_callbacks: %{},
+    log_callback: nil
+  ]
+
+  @doc """
+  Creates a new client state with the given options.
+
+  ## Parameters
+
+    * `opts` - Map containing the initialization options
+
+  ## Options
+
+    * `:client_info` - Information about the client (required)
+    * `:capabilities` - Client capabilities to advertise
+    * `:protocol_version` - Protocol version to use
+    * `:request_timeout` - Default timeout for requests in milliseconds
+    * `:transport` - Transport configuration
+
+  ## Examples
+
+      iex> Hermes.Client.State.new(%{
+      ...>   client_info: %{"name" => "MyClient", "version" => "1.0.0"},
+      ...>   capabilities: %{"resources" => %{}},
+      ...>   protocol_version: "2024-11-05",
+      ...>   request_timeout: 30000,
+      ...>   transport: %{layer: Hermes.Transport.SSE, name: MyTransport}
+      ...> })
+      %Hermes.Client.State{
+        client_info: %{"name" => "MyClient", "version" => "1.0.0"},
+        capabilities: %{"resources" => %{}},
+        protocol_version: "2024-11-05",
+        request_timeout: 30000,
+        transport: %{layer: Hermes.Transport.SSE, name: MyTransport}
+      }
+  """
+  @spec new(map()) :: t()
+  def new(opts) do
+    %__MODULE__{
+      client_info: opts.client_info,
+      capabilities: opts.capabilities,
+      protocol_version: opts.protocol_version,
+      request_timeout: opts.request_timeout,
+      transport: opts.transport
+    }
+  end
+
+  @doc """
+  Adds a new request to the state and returns the request ID and updated state.
+
+  ## Parameters
+
+    * `state` - The current client state
+    * `method` - The method being requested
+    * `params` - The parameters for the request
+    * `from` - The GenServer.from for the caller
+
+  ## Examples
+
+      iex> {req_id, updated_state} = Hermes.Client.State.add_request(state, "ping", %{}, {pid, ref})
+      iex> is_binary(req_id)
+      true
+      iex> map_size(updated_state.pending_requests) > map_size(state.pending_requests)
+      true
+  """
+  @spec add_request(t(), String.t(), map(), GenServer.from()) :: {String.t(), t()}
+  def add_request(state, method, _params, from) do
+    request_id = ID.generate_request_id()
+    timer_ref = Process.send_after(self(), {:request_timeout, request_id}, state.request_timeout)
+    start_time = System.monotonic_time(:millisecond)
+
+    request = {from, method, timer_ref, start_time}
+    pending_requests = Map.put(state.pending_requests, request_id, request)
+
+    {request_id, %{state | pending_requests: pending_requests}}
+  end
+
+  @doc """
+  Gets a request by ID.
+
+  ## Parameters
+
+    * `state` - The current client state
+    * `id` - The request ID to retrieve
+
+  ## Examples
+
+      iex> Hermes.Client.State.get_request(state, "req_123")
+      {{pid, ref}, "ping", timer_ref, start_time} # or nil if not found
+  """
+  @spec get_request(t(), String.t()) :: pending_request() | nil
+  def get_request(state, id) do
+    Map.get(state.pending_requests, id)
+  end
+
+  @doc """
+  Removes a request and returns its info along with the updated state.
+
+  ## Parameters
+
+    * `state` - The current client state
+    * `id` - The request ID to remove
+
+  ## Examples
+
+      iex> {request_info, updated_state} = Hermes.Client.State.remove_request(state, "req_123")
+      iex> request_info.method
+      "ping"
+      iex> request_info.elapsed_ms > 0
+      true
+  """
+  @spec remove_request(t(), String.t()) :: {map() | nil, t()}
+  def remove_request(state, id) do
+    case Map.pop(state.pending_requests, id) do
+      {nil, _} ->
+        {nil, state}
+
+      {{from, method, timer_ref, start_time}, requests} ->
+        # Cancel the timeout timer
+        Process.cancel_timer(timer_ref)
+        elapsed = System.monotonic_time(:millisecond) - start_time
+
+        request_info = %{from: from, method: method, elapsed_ms: elapsed}
+        {request_info, %{state | pending_requests: requests}}
+    end
+  end
+
+  @doc """
+  Handles a request timeout, cancelling the timer and returning the updated state.
+
+  ## Parameters
+
+    * `state` - The current client state
+    * `id` - The request ID that timed out
+
+  ## Examples
+
+      iex> Hermes.Client.State.handle_request_timeout(state, "req_123")
+      {%{from: from, method: "ping", elapsed_ms: 30000}, updated_state}
+  """
+  @spec handle_request_timeout(t(), String.t()) :: {map() | nil, t()}
+  def handle_request_timeout(state, id) do
+    case Map.pop(state.pending_requests, id) do
+      {nil, _} ->
+        {nil, state}
+
+      {{from, method, _timer, start_time}, requests} ->
+        elapsed = System.monotonic_time(:millisecond) - start_time
+        request_info = %{from: from, method: method, elapsed_ms: elapsed}
+
+        {request_info, %{state | pending_requests: requests}}
+    end
+  end
+
+  @doc """
+  Registers a progress callback for a token.
+
+  ## Parameters
+
+    * `state` - The current client state
+    * `token` - The progress token to register a callback for
+    * `callback` - The callback function to call when progress updates are received
+
+  ## Examples
+
+      iex> updated_state = Hermes.Client.State.register_progress_callback(state, "token123", fn token, progress, total -> IO.inspect({token, progress, total}) end)
+      iex> Map.has_key?(updated_state.progress_callbacks, "token123")
+      true
+  """
+  @spec register_progress_callback(t(), String.t(), progress_callback()) :: t()
+  def register_progress_callback(state, token, callback) when is_function(callback, 3) do
+    progress_callbacks = Map.put(state.progress_callbacks, token, callback)
+    %{state | progress_callbacks: progress_callbacks}
+  end
+
+  @doc """
+  Gets a progress callback for a token.
+
+  ## Parameters
+
+    * `state` - The current client state
+    * `token` - The progress token to get the callback for
+
+  ## Examples
+
+      iex> callback = Hermes.Client.State.get_progress_callback(state, "token123")
+      iex> is_function(callback, 3)
+      true
+  """
+  @spec get_progress_callback(t(), String.t()) :: progress_callback() | nil
+  def get_progress_callback(state, token) do
+    Map.get(state.progress_callbacks, token)
+  end
+
+  @doc """
+  Unregisters a progress callback for a token.
+
+  ## Parameters
+
+    * `state` - The current client state
+    * `token` - The progress token to unregister the callback for
+
+  ## Examples
+
+      iex> updated_state = Hermes.Client.State.unregister_progress_callback(state, "token123")
+      iex> Map.has_key?(updated_state.progress_callbacks, "token123")
+      false
+  """
+  @spec unregister_progress_callback(t(), String.t()) :: t()
+  def unregister_progress_callback(state, token) do
+    progress_callbacks = Map.delete(state.progress_callbacks, token)
+    %{state | progress_callbacks: progress_callbacks}
+  end
+
+  @doc """
+  Sets the log callback.
+
+  ## Parameters
+
+    * `state` - The current client state
+    * `callback` - The callback function to call when log messages are received
+
+  ## Examples
+
+      iex> updated_state = Hermes.Client.State.set_log_callback(state, fn level, data, logger -> IO.inspect({level, data, logger}) end)
+      iex> is_function(updated_state.log_callback, 3)
+      true
+  """
+  @spec set_log_callback(t(), log_callback()) :: t()
+  def set_log_callback(state, callback) when is_function(callback, 3) do
+    %{state | log_callback: callback}
+  end
+
+  @doc """
+  Clears the log callback.
+
+  ## Parameters
+
+    * `state` - The current client state
+
+  ## Examples
+
+      iex> updated_state = Hermes.Client.State.clear_log_callback(state)
+      iex> is_nil(updated_state.log_callback)
+      true
+  """
+  @spec clear_log_callback(t()) :: t()
+  def clear_log_callback(state) do
+    %{state | log_callback: nil}
+  end
+
+  @doc """
+  Gets the log callback.
+
+  ## Parameters
+
+    * `state` - The current client state
+
+  ## Examples
+
+      iex> callback = Hermes.Client.State.get_log_callback(state)
+      iex> is_function(callback, 3) or is_nil(callback)
+      true
+  """
+  @spec get_log_callback(t()) :: log_callback() | nil
+  def get_log_callback(state) do
+    state.log_callback
+  end
+
+  @doc """
+  Updates server info and capabilities after initialization.
+
+  ## Parameters
+
+    * `state` - The current client state
+    * `server_capabilities` - The server capabilities received from initialization
+    * `server_info` - The server information received from initialization
+
+  ## Examples
+
+      iex> updated_state = Hermes.Client.State.update_server_info(state, %{"resources" => %{}}, %{"name" => "TestServer"})
+      iex> updated_state.server_capabilities
+      %{"resources" => %{}}
+      iex> updated_state.server_info
+      %{"name" => "TestServer"}
+  """
+  @spec update_server_info(t(), map(), map()) :: t()
+  def update_server_info(state, server_capabilities, server_info) do
+    %{state | server_capabilities: server_capabilities, server_info: server_info}
+  end
+
+  @doc """
+  Returns a list of all pending requests.
+
+  ## Parameters
+
+    * `state` - The current client state
+
+  ## Examples
+
+      iex> requests = Hermes.Client.State.list_pending_requests(state)
+      iex> length(requests) > 0
+      true
+      iex> hd(requests).method
+      "ping"
+  """
+  @spec list_pending_requests(t()) :: list(map())
+  def list_pending_requests(state) do
+    current_time = System.monotonic_time(:millisecond)
+
+    Enum.map(state.pending_requests, fn {id, {_from, method, _timer, start_time}} ->
+      elapsed = current_time - start_time
+      %{id: id, method: method, elapsed_ms: elapsed}
+    end)
+  end
+
+  @doc """
+  Gets the server capabilities.
+
+  ## Parameters
+
+    * `state` - The current client state
+
+  ## Examples
+
+      iex> Hermes.Client.State.get_server_capabilities(state)
+      %{"resources" => %{}, "tools" => %{}}
+  """
+  @spec get_server_capabilities(t()) :: map() | nil
+  def get_server_capabilities(state) do
+    state.server_capabilities
+  end
+
+  @doc """
+  Gets the server info.
+
+  ## Parameters
+
+    * `state` - The current client state
+
+  ## Examples
+
+      iex> Hermes.Client.State.get_server_info(state)
+      %{"name" => "TestServer", "version" => "1.0.0"}
+  """
+  @spec get_server_info(t()) :: map() | nil
+  def get_server_info(state) do
+    state.server_info
+  end
+
+  @doc """
+  Merges additional capabilities into the client's capabilities.
+
+  ## Parameters
+
+    * `state` - The current client state
+    * `additional_capabilities` - The capabilities to merge
+
+  ## Examples
+
+      iex> updated_state = Hermes.Client.State.merge_capabilities(state, %{"tools" => %{"execute" => true}})
+      iex> updated_state.capabilities["tools"]["execute"]
+      true
+  """
+  @spec merge_capabilities(t(), map()) :: t()
+  def merge_capabilities(state, additional_capabilities) do
+    updated_capabilities = deep_merge(state.capabilities, additional_capabilities)
+    %{state | capabilities: updated_capabilities}
+  end
+
+  @doc """
+  Validates if a method is supported by the server's capabilities.
+
+  ## Parameters
+
+    * `state` - The current client state
+    * `method` - The method to validate
+
+  ## Returns
+
+    * `:ok` if the method is supported
+    * `{:error, reason}` if the method is not supported
+
+  ## Examples
+
+      iex> Hermes.Client.State.validate_capability(state_with_resources, "resources/list")
+      :ok
+      
+      iex> Hermes.Client.State.validate_capability(state_without_tools, "tools/list")
+      {:error, {:capability_not_supported, "tools/list"}}
+  """
+  @spec validate_capability(t(), String.t()) :: :ok | {:error, term()}
+  def validate_capability(%{server_capabilities: nil}, _method) do
+    {:error, :server_capabilities_not_set}
+  end
+
+  def validate_capability(%{server_capabilities: _}, "ping"), do: :ok
+  def validate_capability(%{server_capabilities: _}, "initialize"), do: :ok
+
+  def validate_capability(%{server_capabilities: server_capabilities}, method) do
+    capability = String.split(method, "/", parts: 2)
+
+    if valid_capability?(server_capabilities, capability) do
+      :ok
+    else
+      {:error, {:capability_not_supported, method}}
+    end
+  end
+
+  # Helper functions
+
+  defp valid_capability?(_capabilities, ["ping"]), do: true
+  defp valid_capability?(_capabilities, ["initialize"]), do: true
+
+  defp valid_capability?(capabilities, ["resources", sub]) when sub in ~w(subscribe unsubscribe) do
+    if resources = Map.get(capabilities, "resources") do
+      valid_capability?(resources, [sub, nil])
+    end
+  end
+
+  defp valid_capability?(%{} = capabilities, [capability, _]) do
+    Map.has_key?(capabilities, capability)
+  end
+
+  defp deep_merge(map1, map2) do
+    Map.merge(map1, map2, fn
+      _, v1, v2 when is_map(v1) and is_map(v2) -> deep_merge(v1, v2)
+      _, _, v2 -> v2
+    end)
+  end
+end

--- a/test/hermes/client/state_test.exs
+++ b/test/hermes/client/state_test.exs
@@ -1,0 +1,312 @@
+defmodule Hermes.Client.StateTest do
+  use ExUnit.Case, async: true
+
+  alias Hermes.Client.State
+
+  describe "new/1" do
+    test "creates a new state with the given options" do
+      opts = %{
+        client_info: %{"name" => "TestClient", "version" => "1.0.0"},
+        capabilities: %{"resources" => %{}},
+        protocol_version: "2024-11-05",
+        request_timeout: 30_000,
+        transport: %{layer: :fake_transport, name: :fake_name}
+      }
+
+      state = State.new(opts)
+
+      assert state.client_info == %{"name" => "TestClient", "version" => "1.0.0"}
+      assert state.capabilities == %{"resources" => %{}}
+      assert state.protocol_version == "2024-11-05"
+      assert state.request_timeout == 30_000
+      assert state.transport == %{layer: :fake_transport, name: :fake_name}
+      assert state.pending_requests == %{}
+      assert state.progress_callbacks == %{}
+      assert state.log_callback == nil
+    end
+  end
+
+  describe "add_request/4" do
+    test "adds a request to the state" do
+      state = new_test_state()
+      from = {self(), make_ref()}
+
+      {request_id, updated_state} = State.add_request(state, "test_method", %{}, from)
+
+      assert is_binary(request_id)
+      assert Map.has_key?(updated_state.pending_requests, request_id)
+      {stored_from, stored_method, timer_ref, start_time} = updated_state.pending_requests[request_id]
+
+      assert stored_from == from
+      assert stored_method == "test_method"
+      assert is_reference(timer_ref)
+      assert is_integer(start_time)
+    end
+  end
+
+  describe "get_request/2" do
+    test "returns the request if it exists" do
+      state = new_test_state()
+      from = {self(), make_ref()}
+      {request_id, state} = State.add_request(state, "test_method", %{}, from)
+
+      result = State.get_request(state, request_id)
+
+      assert is_tuple(result)
+      assert elem(result, 0) == from
+      assert elem(result, 1) == "test_method"
+    end
+
+    test "returns nil if the request doesn't exist" do
+      state = new_test_state()
+
+      assert State.get_request(state, "nonexistent_id") == nil
+    end
+  end
+
+  describe "remove_request/2" do
+    test "removes a request and returns its info" do
+      state = new_test_state()
+      from = {self(), make_ref()}
+      {request_id, state} = State.add_request(state, "test_method", %{}, from)
+
+      {request_info, updated_state} = State.remove_request(state, request_id)
+
+      assert request_info.from == from
+      assert request_info.method == "test_method"
+      assert is_integer(request_info.elapsed_ms)
+      assert updated_state.pending_requests == %{}
+    end
+
+    test "returns nil if the request doesn't exist" do
+      state = new_test_state()
+
+      {result, updated_state} = State.remove_request(state, "nonexistent_id")
+
+      assert result == nil
+      assert updated_state == state
+    end
+  end
+
+  describe "handle_request_timeout/2" do
+    test "handles a request timeout" do
+      state = new_test_state()
+      from = {self(), make_ref()}
+      {request_id, state} = State.add_request(state, "test_method", %{}, from)
+
+      {request_info, updated_state} = State.handle_request_timeout(state, request_id)
+
+      assert request_info.from == from
+      assert request_info.method == "test_method"
+      assert is_integer(request_info.elapsed_ms)
+      assert updated_state.pending_requests == %{}
+    end
+
+    test "returns nil if the request doesn't exist" do
+      state = new_test_state()
+
+      {result, updated_state} = State.handle_request_timeout(state, "nonexistent_id")
+
+      assert result == nil
+      assert updated_state == state
+    end
+  end
+
+  describe "progress callback management" do
+    test "register_progress_callback/3 registers a callback" do
+      state = new_test_state()
+      token = "test_token"
+      callback = fn _, _, _ -> :ok end
+
+      updated_state = State.register_progress_callback(state, token, callback)
+
+      assert Map.has_key?(updated_state.progress_callbacks, token)
+      assert updated_state.progress_callbacks[token] == callback
+    end
+
+    test "get_progress_callback/2 returns the callback" do
+      state = new_test_state()
+      token = "test_token"
+      callback = fn _, _, _ -> :ok end
+      state = State.register_progress_callback(state, token, callback)
+
+      result = State.get_progress_callback(state, token)
+
+      assert result == callback
+    end
+
+    test "get_progress_callback/2 returns nil if no callback is registered" do
+      state = new_test_state()
+
+      assert State.get_progress_callback(state, "nonexistent_token") == nil
+    end
+
+    test "unregister_progress_callback/2 removes the callback" do
+      state = new_test_state()
+      token = "test_token"
+      callback = fn _, _, _ -> :ok end
+      state = State.register_progress_callback(state, token, callback)
+
+      updated_state = State.unregister_progress_callback(state, token)
+
+      assert not Map.has_key?(updated_state.progress_callbacks, token)
+    end
+  end
+
+  describe "log callback management" do
+    test "set_log_callback/2 sets the callback" do
+      state = new_test_state()
+      callback = fn _, _, _ -> :ok end
+
+      updated_state = State.set_log_callback(state, callback)
+
+      assert updated_state.log_callback == callback
+    end
+
+    test "clear_log_callback/1 clears the callback" do
+      state = new_test_state()
+      callback = fn _, _, _ -> :ok end
+      state = State.set_log_callback(state, callback)
+
+      updated_state = State.clear_log_callback(state)
+
+      assert updated_state.log_callback == nil
+    end
+
+    test "get_log_callback/1 returns the callback" do
+      state = new_test_state()
+      callback = fn _, _, _ -> :ok end
+      state = State.set_log_callback(state, callback)
+
+      result = State.get_log_callback(state)
+
+      assert result == callback
+    end
+  end
+
+  describe "update_server_info/3" do
+    test "updates server capabilities and info" do
+      state = new_test_state()
+      capabilities = %{"resources" => %{}, "tools" => %{}}
+      server_info = %{"name" => "TestServer", "version" => "1.0.0"}
+
+      updated_state = State.update_server_info(state, capabilities, server_info)
+
+      assert updated_state.server_capabilities == capabilities
+      assert updated_state.server_info == server_info
+    end
+  end
+
+  describe "list_pending_requests/1" do
+    test "returns a list of pending requests" do
+      state = new_test_state()
+      from = {self(), make_ref()}
+      {request_id, state} = State.add_request(state, "test_method", %{}, from)
+
+      requests = State.list_pending_requests(state)
+
+      assert length(requests) == 1
+      request = hd(requests)
+      assert request.id == request_id
+      assert request.method == "test_method"
+      assert is_integer(request.elapsed_ms)
+    end
+
+    test "returns an empty list if there are no pending requests" do
+      state = new_test_state()
+
+      assert State.list_pending_requests(state) == []
+    end
+  end
+
+  describe "server capabilities and info" do
+    test "get_server_capabilities/1 returns the server capabilities" do
+      state = new_test_state()
+      capabilities = %{"resources" => %{}, "tools" => %{}}
+      state = %{state | server_capabilities: capabilities}
+
+      assert State.get_server_capabilities(state) == capabilities
+    end
+
+    test "get_server_info/1 returns the server info" do
+      state = new_test_state()
+      server_info = %{"name" => "TestServer", "version" => "1.0.0"}
+      state = %{state | server_info: server_info}
+
+      assert State.get_server_info(state) == server_info
+    end
+  end
+
+  describe "merge_capabilities/2" do
+    test "merges additional capabilities" do
+      state = new_test_state()
+      state = %{state | capabilities: %{"resources" => %{}}}
+
+      updated_state = State.merge_capabilities(state, %{"tools" => %{"execute" => true}})
+
+      assert updated_state.capabilities == %{
+               "resources" => %{},
+               "tools" => %{"execute" => true}
+             }
+    end
+
+    test "deeply merges nested capabilities" do
+      state = new_test_state()
+      state = %{state | capabilities: %{"resources" => %{"list" => true}}}
+
+      updated_state = State.merge_capabilities(state, %{"resources" => %{"read" => true}})
+
+      assert updated_state.capabilities == %{
+               "resources" => %{"list" => true, "read" => true}
+             }
+    end
+  end
+
+  describe "validate_capability/2" do
+    test "returns :ok for ping method" do
+      state = new_test_state()
+      state = %{state | server_capabilities: %{}}
+
+      assert State.validate_capability(state, "ping") == :ok
+    end
+
+    test "returns :ok for initialize method" do
+      state = new_test_state()
+      state = %{state | server_capabilities: %{}}
+
+      assert State.validate_capability(state, "initialize") == :ok
+    end
+
+    test "returns :ok for supported capability" do
+      state = new_test_state()
+      state = %{state | server_capabilities: %{"resources" => %{}}}
+
+      assert State.validate_capability(state, "resources/list") == :ok
+    end
+
+    test "returns error for unsupported capability" do
+      state = new_test_state()
+      state = %{state | server_capabilities: %{"resources" => %{}}}
+
+      assert State.validate_capability(state, "tools/list") == {:error, {:capability_not_supported, "tools/list"}}
+    end
+
+    test "returns error when server capabilities are not set" do
+      state = new_test_state()
+
+      assert State.validate_capability(state, "resources/list") == {:error, :server_capabilities_not_set}
+    end
+  end
+
+  # Helper functions
+
+  defp new_test_state do
+    %State{
+      client_info: %{"name" => "TestClient", "version" => "1.0.0"},
+      capabilities: %{},
+      protocol_version: "2024-11-05",
+      request_timeout: 30_000,
+      transport: %{layer: :fake_transport, name: :fake_name}
+    }
+  end
+end

--- a/test/hermes/client_test.exs
+++ b/test/hermes/client_test.exs
@@ -3,6 +3,7 @@ defmodule Hermes.ClientTest do
 
   import Mox
 
+  alias Hermes.Client.State
   alias Hermes.Message
 
   @moduletag capture_log: true
@@ -14,6 +15,17 @@ defmodule Hermes.ClientTest do
     Mox.stub_with(Hermes.MockTransport, Hermes.MockTransportImpl)
 
     :ok
+  end
+
+  # Helper function to get request_id from state
+  defp get_request_id(client, expected_method) do
+    state = :sys.get_state(client)
+    pending_requests = State.list_pending_requests(state)
+
+    Enum.find_value(pending_requests, nil, fn
+      %{method: ^expected_method, id: id} -> id
+      _ -> nil
+    end)
   end
 
   describe "start_link/1" do
@@ -61,8 +73,7 @@ defmodule Hermes.ClientTest do
       Process.send(client, :initialize, [:noconnect])
       Process.sleep(50)
 
-      state = :sys.get_state(client)
-      [{request_id, {_pid, "initialize"}}] = Map.to_list(state.pending_requests)
+      assert request_id = get_request_id(client, "initialize")
 
       init_response = %{
         "id" => request_id,
@@ -96,8 +107,7 @@ defmodule Hermes.ClientTest do
 
       Process.sleep(50)
 
-      state = :sys.get_state(client)
-      [{request_id, {_from, "ping"}}] = Map.to_list(state.pending_requests)
+      assert request_id = get_request_id(client, "ping")
 
       response = %{
         "id" => request_id,
@@ -123,8 +133,7 @@ defmodule Hermes.ClientTest do
 
       Process.sleep(50)
 
-      state = :sys.get_state(client)
-      [{request_id, {_from, "resources/list"}}] = Map.to_list(state.pending_requests)
+      assert request_id = get_request_id(client, "resources/list")
 
       response = %{
         "id" => request_id,
@@ -158,8 +167,7 @@ defmodule Hermes.ClientTest do
 
       Process.sleep(50)
 
-      state = :sys.get_state(client)
-      [{request_id, {_from, "resources/list"}}] = Map.to_list(state.pending_requests)
+      assert request_id = get_request_id(client, "resources/list")
 
       response = %{
         "id" => request_id,
@@ -193,8 +201,7 @@ defmodule Hermes.ClientTest do
 
       Process.sleep(50)
 
-      state = :sys.get_state(client)
-      [{request_id, {_from, "resources/read"}}] = Map.to_list(state.pending_requests)
+      assert request_id = get_request_id(client, "resources/read")
 
       response = %{
         "id" => request_id,
@@ -226,8 +233,7 @@ defmodule Hermes.ClientTest do
 
       Process.sleep(50)
 
-      state = :sys.get_state(client)
-      [{request_id, {_from, "prompts/list"}}] = Map.to_list(state.pending_requests)
+      assert request_id = get_request_id(client, "prompts/list")
 
       response = %{
         "id" => request_id,
@@ -269,8 +275,7 @@ defmodule Hermes.ClientTest do
 
       Process.sleep(50)
 
-      state = :sys.get_state(client)
-      [{request_id, {_from, "prompts/get"}}] = Map.to_list(state.pending_requests)
+      assert request_id = get_request_id(client, "prompts/get")
 
       response = %{
         "id" => request_id,
@@ -302,8 +307,7 @@ defmodule Hermes.ClientTest do
 
       Process.sleep(50)
 
-      state = :sys.get_state(client)
-      [{request_id, {_from, "tools/list"}}] = Map.to_list(state.pending_requests)
+      assert request_id = get_request_id(client, "tools/list")
 
       response = %{
         "id" => request_id,
@@ -338,8 +342,7 @@ defmodule Hermes.ClientTest do
 
       Process.sleep(50)
 
-      state = :sys.get_state(client)
-      [{request_id, {_from, "tools/call"}}] = Map.to_list(state.pending_requests)
+      assert request_id = get_request_id(client, "tools/call")
 
       response = %{
         "id" => request_id,
@@ -379,8 +382,7 @@ defmodule Hermes.ClientTest do
       Process.send(client, :initialize, [:noconnect])
       Process.sleep(50)
 
-      state = :sys.get_state(client)
-      [{request_id, {_pid, "initialize"}}] = Map.to_list(state.pending_requests)
+      assert request_id = get_request_id(client, "initialize")
 
       init_response = %{
         "id" => request_id,
@@ -414,8 +416,7 @@ defmodule Hermes.ClientTest do
 
       Process.sleep(50)
 
-      state = :sys.get_state(client)
-      [{request_id, {_from, "ping"}}] = Map.to_list(state.pending_requests)
+      assert request_id = get_request_id(client, "ping")
 
       response = %{
         "id" => request_id,
@@ -453,8 +454,7 @@ defmodule Hermes.ClientTest do
       Process.send(client, :initialize, [:noconnect])
       Process.sleep(50)
 
-      state = :sys.get_state(client)
-      [{request_id, {_pid, "initialize"}}] = Map.to_list(state.pending_requests)
+      assert request_id = get_request_id(client, "initialize")
 
       init_response = %{
         "id" => request_id,
@@ -483,8 +483,7 @@ defmodule Hermes.ClientTest do
 
       Process.sleep(50)
 
-      state = :sys.get_state(client)
-      [{request_id, {_from, "ping"}}] = Map.to_list(state.pending_requests)
+      assert request_id = get_request_id(client, "ping")
 
       error_response = %{
         "id" => request_id,
@@ -565,8 +564,7 @@ defmodule Hermes.ClientTest do
       Process.send(client, :initialize, [:noconnect])
       Process.sleep(50)
 
-      state = :sys.get_state(client)
-      [{request_id, {_pid, "initialize"}}] = Map.to_list(state.pending_requests)
+      assert request_id = get_request_id(client, "initialize")
 
       init_response = %{
         "id" => request_id,
@@ -622,8 +620,7 @@ defmodule Hermes.ClientTest do
       Process.send(client, :initialize, [:noconnect])
       Process.sleep(50)
 
-      state = :sys.get_state(client)
-      [{request_id, {_pid, "initialize"}}] = Map.to_list(state.pending_requests)
+      assert request_id = get_request_id(client, "initialize")
 
       init_response = %{
         "id" => request_id,
@@ -725,8 +722,7 @@ defmodule Hermes.ClientTest do
       Process.sleep(50)
 
       # Simulate a response to complete the request
-      state = :sys.get_state(client)
-      [{request_id, {_from, "resources/list"}}] = Map.to_list(state.pending_requests)
+      assert request_id = get_request_id(client, "resources/list")
 
       response = %{
         "id" => request_id,
@@ -774,8 +770,7 @@ defmodule Hermes.ClientTest do
       Process.send(client, :initialize, [:noconnect])
       Process.sleep(50)
 
-      state = :sys.get_state(client)
-      [{request_id, {_pid, "initialize"}}] = Map.to_list(state.pending_requests)
+      assert request_id = get_request_id(client, "initialize")
 
       init_response = %{
         "id" => request_id,
@@ -807,8 +802,7 @@ defmodule Hermes.ClientTest do
 
       Process.sleep(50)
 
-      state = :sys.get_state(client)
-      [{request_id, {_from, "logging/setLevel"}}] = Map.to_list(state.pending_requests)
+      assert request_id = get_request_id(client, "logging/setLevel")
 
       response = %{
         "id" => request_id,
@@ -898,8 +892,7 @@ defmodule Hermes.ClientTest do
       Process.send(client, :initialize, [:noconnect])
       Process.sleep(50)
 
-      state = :sys.get_state(client)
-      [{request_id, {_pid, "initialize"}}] = Map.to_list(state.pending_requests)
+      assert request_id = get_request_id(client, "initialize")
 
       init_response = %{
         "id" => request_id,


### PR DESCRIPTION
## Problem

The current client implementation has state management logic mixed within the GenServer
lifecycle, making it harder to test, maintain, and extend. Direct state access through
GenServer creates tight coupling and prevents separation of concerns.

## Solution

Implement a struct-based state management pattern by:
1. Refactoring client state into a dedicated Hermes.Client.State module
2. Extracting state manipulation logic from the GenServer
3. Providing clear state transformation functions with proper typespecs
4. Updating the Client module to delegate state operations to the State module
5. Modifying tests to use the new state access patterns

## Rationale

This architectural improvement provides several benefits:
- Better separation of concerns: state logic is now isolated from process lifecycle
- Improved testability: state operations can be tested independently
- Enhanced maintainability: state structure changes are localized to a single module
- Clearer code ownership: state transformations are explicit and documented
- Type safety: proper typespecs enforce correct state handling
