### PR TITLE
fix: do not handle domain errors

### DIFF
--- a/lib/hermes/client.ex
+++ b/lib/hermes/client.ex
@@ -602,17 +602,10 @@ defmodule Hermes.Client do
         # Convert to our domain response
         response = Response.from_json_rpc(%{"result" => result, "id" => id})
 
-        # Unblock original caller with result
-        cond do
-          request_info.method == "ping" ->
-            GenServer.reply(request_info.from, :pong)
-
-          Response.error?(response) ->
-            error = Error.domain_error(response.result)
-            GenServer.reply(request_info.from, {:error, error})
-
-          true ->
-            GenServer.reply(request_info.from, {:ok, response.result})
+        if request_info.method == "ping" do
+          GenServer.reply(request_info.from, :pong)
+        else
+          GenServer.reply(request_info.from, {:ok, response})
         end
 
         updated_state

--- a/lib/hermes/mcp/response.ex
+++ b/lib/hermes/mcp/response.ex
@@ -80,25 +80,23 @@ defmodule Hermes.MCP.Response do
   end
 
   @doc """
-  Unwraps the response, handling domain-level errors.
+  Unwraps the response, returning the raw result.
 
-  Returns either:
-  - `{:ok, result}` for successful responses
-  - `{:error, result}` for responses with isError: true
+  Returns the raw result data regardless of whether it represents
+  a success or domain error.
 
   ## Examples
 
       iex> response = Hermes.MCP.Response.from_json_rpc(%{"result" => %{"data" => "value"}, "id" => "req_123"})
       iex> Hermes.MCP.Response.unwrap(response)
-      {:ok, %{"data" => "value"}}
+      %{"data" => "value"}
       
       iex> error_response = Hermes.MCP.Response.from_json_rpc(%{"result" => %{"isError" => true, "reason" => "not_found"}, "id" => "req_123"})
       iex> Hermes.MCP.Response.unwrap(error_response)
-      {:error, %{"isError" => true, "reason" => "not_found"}}
+      %{"isError" => true, "reason" => "not_found"}
   """
-  @spec unwrap(t()) :: {:ok, map()} | {:error, map()}
-  def unwrap(%__MODULE__{result: result, is_error: false}), do: {:ok, result}
-  def unwrap(%__MODULE__{result: result, is_error: true}), do: {:error, result}
+  @spec unwrap(t()) :: map()
+  def unwrap(%__MODULE__{result: result}), do: result
 
   @doc """
   Checks if the response is successful (no domain error).

--- a/test/hermes/mcp/response_test.exs
+++ b/test/hermes/mcp/response_test.exs
@@ -53,24 +53,21 @@ defmodule Hermes.MCP.ResponseTest do
   end
 
   describe "unwrap/1" do
-    test "returns {:ok, result} for successful responses" do
-      response = %Response{
+    test "returns the raw result for any response" do
+      success_response = %Response{
         result: %{"data" => "value"},
         id: "req_123",
         is_error: false
       }
 
-      assert Response.unwrap(response) == {:ok, %{"data" => "value"}}
-    end
-
-    test "returns {:error, result} for domain errors" do
-      response = %Response{
+      error_response = %Response{
         result: %{"isError" => true, "reason" => "not_found"},
         id: "req_123",
         is_error: true
       }
 
-      assert Response.unwrap(response) == {:error, %{"isError" => true, "reason" => "not_found"}}
+      assert Response.unwrap(success_response) == %{"data" => "value"}
+      assert Response.unwrap(error_response) == %{"isError" => true, "reason" => "not_found"}
     end
   end
 


### PR DESCRIPTION
## Problem

Domain errors were being transformed from valid JSON-RPC responses into custom error
tuples, hiding the original response structure.

## Solution

Return domain errors as successful responses with the is_error flag set to true,
preserving the complete original structure and allowing more flexibility in error
handling.

## Rationale

This approach maintains a clearer separation between protocol errors and domain-level
errors, giving clients more control over how to handle application-specific error
states.
