### PR TITLE
feat: improve sse uri path handling

### DIFF
--- a/lib/hermes/transport/sse.ex
+++ b/lib/hermes/transport/sse.ex
@@ -32,6 +32,7 @@ defmodule Hermes.Transport.SSE do
   alias Hermes.SSE
   alias Hermes.SSE.Event
   alias Hermes.Transport.Behaviour, as: Transport
+  alias Hermes.URI, as: HermesURI
 
   require Logger
 
@@ -76,7 +77,7 @@ defmodule Hermes.Transport.SSE do
   @impl GenServer
   def init(%{} = opts) do
     server_url = make_server_url(opts.server)
-    sse_url = URI.append_path(server_url, opts.server[:sse_path])
+    sse_url = HermesURI.join_path(server_url, opts.server[:sse_path])
 
     state =
       opts
@@ -156,9 +157,9 @@ defmodule Hermes.Transport.SSE do
   end
 
   @impl GenServer
-  def handle_info({:endpoint, endpoint}, %{client: client, server: server} = state) do
+  def handle_info({:endpoint, endpoint}, %{client: client, server_url: server_url} = state) do
     Process.send(client, :initialize, [:noconnect])
-    message_url = URI.append_path(server[:base_url], endpoint)
+    message_url = HermesURI.join_path(server_url, endpoint)
     {:noreply, %{state | message_url: message_url}}
   end
 
@@ -202,9 +203,6 @@ defmodule Hermes.Transport.SSE do
   end
 
   defp make_server_url(server_opts) do
-    url = server_opts[:base_url]
-    path = server_opts[:base_path]
-
-    URI.append_path(url, path)
+    HermesURI.join_path(server_opts[:base_url], server_opts[:base_path])
   end
 end

--- a/lib/hermes/uri.ex
+++ b/lib/hermes/uri.ex
@@ -1,0 +1,49 @@
+defmodule Hermes.URI do
+  @moduledoc """
+  URI utilities for handling URL paths consistently.
+  """
+
+  @doc """
+  Joins a base URI with a path segment, handling trailing and leading slashes correctly.
+
+  ## Examples
+      iex> Hermes.URI.join_path(URI.new!("http://localhost:8000"), "/mcp")
+      %URI{scheme: "http", host: "localhost", port: 8000, path: "/mcp"}
+      
+      iex> Hermes.URI.join_path(URI.new!("http://localhost:8000/"), "/mcp")
+      %URI{scheme: "http", host: "localhost", port: 8000, path: "/mcp"}
+      
+      iex> Hermes.URI.join_path(URI.new!("http://localhost:8000/api"), "/mcp")
+      %URI{scheme: "http", host: "localhost", port: 8000, path: "/api/mcp"}
+  """
+  @spec join_path(URI.t(), String.t()) :: URI.t()
+  def join_path(base_uri, path) when is_binary(path) do
+    base_path = base_uri.path || ""
+
+    segments =
+      [base_path, path]
+      |> Enum.map(&String.trim(&1, "/"))
+      |> Enum.reject(&(&1 == ""))
+
+    normalized_path = "/" <> Enum.join(segments, "/")
+    %{base_uri | path: normalized_path}
+  end
+
+  def join_path(base_uri, nil), do: base_uri
+
+  @doc """
+  Joins a base URI with multiple path segments, handling trailing and leading slashes correctly.
+  """
+  @spec join_paths(URI.t(), [String.t()]) :: URI.t()
+  def join_paths(base_uri, paths) when is_list(paths) do
+    base_path = base_uri.path || ""
+
+    segments =
+      [base_path | paths]
+      |> Enum.map(&String.trim(&1, "/"))
+      |> Enum.reject(&(&1 == ""))
+
+    normalized_path = "/" <> Enum.join(segments, "/")
+    %{base_uri | path: normalized_path}
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Hermes.MixProject do
   use Mix.Project
 
-  @version "0.3.2"
+  @version "0.3.3"
   @source_url "https://github.com/cloudwalk/hermes-mcp"
 
   def project do

--- a/test/hermes/uri_test.exs
+++ b/test/hermes/uri_test.exs
@@ -1,0 +1,72 @@
+defmodule Hermes.URITest do
+  use ExUnit.Case, async: true
+
+  alias Hermes.URI, as: HermesURI
+
+  describe "join_path/2" do
+    test "joins base URL without trailing slash with path with leading slash" do
+      base_uri = URI.new!("http://localhost:8000")
+      path = "/mcp"
+
+      result = HermesURI.join_path(base_uri, path)
+      assert result.path == "/mcp"
+    end
+
+    test "joins base URL with trailing slash with path with leading slash" do
+      base_uri = URI.new!("http://localhost:8000/")
+      path = "/mcp"
+
+      result = HermesURI.join_path(base_uri, path)
+      assert result.path == "/mcp"
+    end
+
+    test "joins base URL with path to another path" do
+      base_uri = URI.new!("http://localhost:8000/api")
+      path = "/mcp"
+
+      result = HermesURI.join_path(base_uri, path)
+      assert result.path == "/api/mcp"
+    end
+
+    test "joins base URL without trailing slash with path without leading slash" do
+      base_uri = URI.new!("http://localhost:8000")
+      path = "mcp"
+
+      result = HermesURI.join_path(base_uri, path)
+      assert result.path == "/mcp"
+    end
+
+    test "joins base URL with trailing slash with path without leading slash" do
+      base_uri = URI.new!("http://localhost:8000/")
+      path = "mcp"
+
+      result = HermesURI.join_path(base_uri, path)
+      assert result.path == "/mcp"
+    end
+
+    test "handles nil path" do
+      base_uri = URI.new!("http://localhost:8000/api")
+
+      result = HermesURI.join_path(base_uri, nil)
+      assert result == base_uri
+    end
+  end
+
+  describe "join_paths/2" do
+    test "joins multiple path segments" do
+      base_uri = URI.new!("http://localhost:8000")
+      paths = ["api", "v1", "users"]
+
+      result = HermesURI.join_paths(base_uri, paths)
+      assert result.path == "/api/v1/users"
+    end
+
+    test "joins multiple path segments with mixed leading/trailing slashes" do
+      base_uri = URI.new!("http://localhost:8000/")
+      paths = ["/api/", "v1", "/users"]
+
+      result = HermesURI.join_paths(base_uri, paths)
+      assert result.path == "/api/v1/users"
+    end
+  end
+end


### PR DESCRIPTION

## Problem

The SSE transport had inconsistent URL path handling which caused connection issues
depending on how base_url and base_path were configured. Some configurations would work
for SSE initialization but break for message endpoints.

## Solution

Created a new Hermes.URI module with standardized path joining logic that correctly
handles all combinations of base URLs and path segments with proper slash
normalization.

## Rationale

The simplified approach using path segment splitting and joining is more readable and
robust than complex string manipulation, avoiding edge cases with trailing and leading
slashes while ensuring consistent path construction.
