### PR TITLE
improve cli compilation and setup/contribution guides

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,0 +1,2 @@
+export HERMES_MCP_COMPILE_CLI=true
+export MIX_ENV=prod

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
       token: read
     env:
       MIX_ENV: prod
+      HERMES_MCP_COMPILE_CLI: "true"
     
     steps:
       - name: Checkout code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,112 @@
+# Contributing to Hermes MCP
+
+Thank you for your interest in contributing to Hermes MCP! This document provides guidelines and instructions for contributing to the project.
+
+Firstly, have sure to follow the official MCP (Model Context Protocol) [specification](https://spec.modelcontextprotocol.io/specification/2024-11-05/)!
+
+## Development Setup
+
+### Prerequisites
+
+- Elixir 1.18+
+- Erlang/OTP 26+
+- Python 3.11+ with uv (for echo server)
+- Go 1.21+ (for calculator server)
+- Just command runner
+
+### Getting Started
+
+1. Clone the repository
+   ```bash
+   git clone https://github.com/cloudwalk/hermes-mcp.git
+   cd hermes-mcp
+   ```
+
+2. Install dependencies
+   ```bash
+   mix setup
+   ```
+
+3. Run tests to ensure everything is working
+   ```bash
+   mix test
+   ```
+
+## Development Workflow
+
+### Running MCP Servers
+
+For development and testing, you can use the provided MCP server implementations:
+
+```bash
+# Start the Echo server (Python)
+# For now only support stdio transport
+just echo-server
+
+# Start the Calculator server (Go)
+# Supports both stdio and http/sse transpot
+just calculator-server sse
+```
+
+### Code Quality
+
+Before submitting a pull request, ensure your code passes all quality checks:
+
+```bash
+# Run all code quality checks
+mix lint
+
+# Individual checks
+mix format        # Code formatting
+mix credo         # Linting
+mix dialyzer      # Type checking
+```
+
+### Testing
+
+Write tests for all new features and bug fixes:
+
+```bash
+# Run all tests
+mix test
+```
+
+## Submitting Contributions
+
+1. Create a new branch for your feature or bugfix
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```
+
+2. Make your changes and commit them with clear, descriptive messages
+
+3. Push your branch to GitHub
+   ```bash
+   git push origin feature/your-feature-name
+   ```
+
+4. Open a pull request against the main branch
+
+## Pull Request Guidelines
+
+- Follow the existing code style and conventions
+- Include tests for new functionality
+- Update documentation as needed
+- Keep pull requests focused on a single topic
+- Reference any related issues in your PR description
+
+## Documentation
+
+Update documentation for any user-facing changes:
+
+- Update relevant sections in `pages/` directory
+- Add examples for new features
+- Document any breaking changes
+
+## Release Process
+
+Releases are managed by the maintainers. Version numbers follow [Semantic Versioning](https://semver.org/).
+
+## License
+
+By contributing to Hermes MCP, you agree that your contributions will be licensed under the project's [MIT License](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -39,10 +39,6 @@ end
 
 ### Standalone CLI Installation
 
-You can use Hermes MCP CLI in one of the following ways:
-
-#### Option 1: Using Pre-built Binaries
-
 Download the appropriate binary for your platform from the [GitHub releases page](https://github.com/cloudwalk/hermes-mcp/releases).
 
 ```bash
@@ -53,14 +49,6 @@ mv hermes_mcp_linux hermes-mcp && chmod +x hermes-mcp
 # Run it
 ./hermes-mcp --transport sse --base-url="http://localhost:8000"
 ```
-
-#### Option 2: Mix Archive (For Elixir Developers)
-
-```bash
-mix archive.install hex hermes_mcp
-```
-
-This makes the mix tasks available globally.
 
 ## Quick Start
 
@@ -153,6 +141,31 @@ For detailed guides and examples, visit the [official documentation](https://hex
 The library is named after Hermes, the Greek god of boundaries, communication, and commerce. This namesake reflects the core purpose of the Model Context Protocol: to establish standardized communication between AI applications and external tools.
 
 Like Hermes who served as a messenger between gods and mortals, this library facilitates seamless interaction between Large Language Models and various data sources or tools.
+
+## Local Development
+
+```bash
+# Setup the project
+mix setup
+
+# Run tests
+mix test
+
+# Code quality
+mix lint
+
+# Start development MCP servers
+# Echo server (Python)
+just echo-server
+# Calculator server (Go)
+just calculator-server
+```
+
+The MCP servers in `priv/dev` require:
+- Python 3.11+ with uv (for echo server)
+- Go 1.21+ (for calculator server)
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for detailed contribution guidelines.
 
 ## License
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,10 @@
 import Config
 
-config :hermes_mcp, env: config_env()
+boolean = fn env ->
+  System.get_env(env) in ["1", "true"]
+end
+
+config :hermes_mcp, compile_cli?: boolean.("HERMES_MCP_COMPILE_CLI")
 
 config :logger, :default_formatter,
   format: "[$level] $message $metadata\n",

--- a/lib/hermes.ex
+++ b/lib/hermes.ex
@@ -1,8 +1,9 @@
 defmodule Hermes do
   @moduledoc false
 
-  def env do
-    Application.get_env(:hermes_mcp, :env, :dev)
+  @doc "Checks if hermes should be compiled/used as standlone CLI or OTP library"
+  def should_compile_cli? do
+    Application.get_env(:hermes_mcp, :compile_cli?, false)
   end
 
   @doc """

--- a/lib/hermes/application.ex
+++ b/lib/hermes/application.ex
@@ -16,7 +16,7 @@ defmodule Hermes.Application do
     opts = [strategy: :one_for_one, name: Hermes.Supervisor]
     {:ok, pid} = Supervisor.start_link(children, opts)
 
-    if Hermes.env() == :prod do
+    if Hermes.should_compile_cli?() do
       Hermes.CLI.main()
       {:ok, pid}
     else

--- a/mix.exs
+++ b/mix.exs
@@ -81,7 +81,10 @@ defmodule Hermes.MixProject do
   end
 
   defp aliases do
-    [setup: ["deps.get", "compile --force"]]
+    [
+      setup: ["deps.get", "compile --force"],
+      lint: ["format --check-formatted", "credo --strict", "dialyzer"]
+    ]
   end
 
   defp docs do


### PR DESCRIPTION
## Problem

The CLI compilation process was inconsistent and the project lacked proper contribution
guidelines.

## Solution

Added CONTRIBUTING.md, an environment flag to control CLI compilation, and updated configuration
to make CLI compilation more deterministic.

## Rationale

Using an environment variable (HERMES_MCP_COMPILE_CLI) provides a clear way to control when the
application should be built as a CLI vs. a library, improving flexibility for both development
and release workflows.
