### PR TITLE
feat: implement termination cleanup on Hermes.Client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ hermes_mcp-*.tar
 
 # Burrito specific
 /burrito_out/
+
+# Local envs
+.env.*

--- a/lib/hermes/transport/sse.ex
+++ b/lib/hermes/transport/sse.ex
@@ -201,8 +201,7 @@ defmodule Hermes.Transport.SSE do
   end
 
   @impl GenServer
-  def handle_cast(:close_connection, %{stream_task: task} = state) do
-    Task.shutdown(task, to_timeout(second: 3))
+  def handle_cast(:close_connection, state) do
     {:stop, :normal, state}
   end
 


### PR DESCRIPTION
## Problem

The client was closing the transport connection in both handle_cast(:close) and terminate/2,
 potentially causing duplicate termination attempts that could lead to race conditions.

## Solution

Added a proper terminate/2 callback to the client that handles cleanup tasks previously done
 in handle_cast(:close), including notifying of cancelled requests and shutting down the
transport layer.

## Rationale

By moving the cleanup logic to the terminate/2 callback, we ensure these operations happen
exactly once during the shutdown process, avoiding duplicate termination calls between the
client and transport layers.
