### PR TITLE
feat: roadmap and protocol update proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,21 +12,40 @@ A high-performance Model Context Protocol (MCP) implementation in Elixir.
 
 ## Overview
 
-Hermes MCP provides a robust client implementation for the [Model Context Protocol](https://spec.modelcontextprotocol.io/specification/2024-11-05/), leveraging Elixir's exceptional concurrency model and fault tolerance capabilities.
+Hermes MCP is a comprehensive Elixir SDK for the [Model Context Protocol](https://spec.modelcontextprotocol.io/), aiming to provide complete client and server implementations. The library leverages Elixir's exceptional concurrency model and fault tolerance capabilities to deliver a robust MCP experience.
+
+Currently, Hermes MCP offers a feature-complete client implementation conforming to the MCP 2024-11-05 specification. Server-side components are planned for future releases.
 
 ## Roadmap
 
-- [x] Complete client implementation with protocol lifecycle management
+### Current Status
+
+- [x] Complete client implementation (MCP 2024-11-05)
 - [x] Multiple transport options (STDIO and HTTP/SSE)
 - [x] Built-in connection supervision and automatic recovery
 - [x] Comprehensive capability negotiation
-- [x] Progress notification support for tracking long-running operations
-- [x] Structured logging system with log level control
-- [ ] Server implementation using STDIO
-- [ ] Server implementation using HTTP/SSE 
-- [ ] Sample server implementation: Hex Packages 
-- [ ] Sample server implementation: Ash Documentation 
-- [ ] Sample server implementation: Oban Documentation
+- [x] Progress tracking and cancellation support
+- [x] Structured logging system
+
+### Upcoming
+
+- [ ] Client support for MCP 2025-03-26 specification
+  - Authorization framework (OAuth 2.1)
+  - Streamable HTTP transport
+  - JSON-RPC batch operations
+  - Enhanced tool annotations
+
+- [ ] Server Implementation
+  - STDIO transport
+  - HTTP/SSE transport
+  - Streamable HTTP transport
+  - Support for resources, tools, and prompts
+
+- [ ] Sample Implementations
+  - Reference servers
+  - Integration examples with popular Elixir libraries
+
+For a more detailed roadmap, see [ROADMAP.md](./ROADMAP.md).
 
 ## Installation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,98 @@
+# Hermes MCP Roadmap
+
+This document outlines the development roadmap for Hermes MCP, an Elixir implementation of the Model Context Protocol (MCP). The roadmap is organized by key milestones and development areas.
+
+## Current Status
+
+Hermes MCP currently provides a complete client implementation for the MCP 2024-11-05 specification with:
+
+- Full protocol lifecycle management (initialization, operation, shutdown)
+- Multiple transport options (STDIO and HTTP/SSE)
+- Connection supervision and automatic recovery
+- Comprehensive capability negotiation
+- Progress tracking for long-running operations
+- Cancellation support
+- Structured logging
+- Interactive test shell for development
+
+## Upcoming Milestones
+
+### 1. MCP 2025-03-26 Specification Support
+
+The MCP specification was updated on 2025-03-26 with several breaking changes and new features. Our implementation plan includes:
+
+#### Phase 1: Core Infrastructure (Q2 2025)
+
+- Support for protocol version negotiation
+- Multi-version compatibility layer
+- Backward compatibility with 2024-11-05 servers
+
+#### Phase 2: Transport Layer Updates (Q2-Q3 2025)
+
+- Implement Streamable HTTP transport
+- Maintain compatibility with HTTP+SSE for older servers
+- Support session management via `Mcp-Session-Id` header
+- Implement stream resumability with `Last-Event-ID`
+
+#### Phase 3: New Protocol Features (Q3 2025)
+
+- Support for OAuth 2.1 authorization framework
+  - Server metadata discovery
+  - Dynamic client registration
+  - Token management and refresh
+- JSON-RPC batching for improved performance
+- Enhanced tool annotations
+- Explicit completions capability
+- Audio content type support
+- Message field for progress notifications
+
+See [protocol_upgrade_2025_03_26.md](./pages/protocol_upgrade_2025_03_26.md) for detailed information about these changes.
+
+### 2. Server Implementation (Q3-Q4 2025)
+
+After stabilizing the client implementation for both protocol versions, we plan to develop a complete server-side implementation:
+
+#### Phase 1: Core Server Infrastructure
+
+- Server-side protocol implementation
+- Capability management
+- Request handling framework
+- Resource, prompt, and tool abstractions
+
+#### Phase 2: Transport Implementations
+
+- STDIO transport for local process communication
+- HTTP/SSE transport for 2024-11-05 compatibility
+- Streamable HTTP transport for 2025-03-26 support
+
+#### Phase 3: Feature Implementations
+
+- Resources management and subscription
+- Tools registration and invocation
+- Prompts template system
+- Logging and telemetry
+- Authorization framework
+
+### 3. Sample Implementations and Integration Examples (Q4 2025+)
+
+Once both client and server implementations are stable, we plan to provide:
+
+- Reference server implementations
+- Sample integration with Elixir ecosystem libraries
+- Example applications demonstrating MCP use cases
+- Integration with popular AI frameworks and platforms
+
+## Feature Backlog
+
+Beyond the core roadmap, we maintain a backlog of features for future consideration:
+
+- **WebSockets Transport**: Alternative transport layer for bidirectional communication
+- **Observability**: Advanced telemetry and monitoring integration
+- **Rate Limiting and Quota Management**: For server implementations
+- **Testing Tools**: Extended tools for protocol testing and validation
+
+## Contributing
+
+We welcome contributions to any part of this roadmap. See [CONTRIBUTING.md](./CONTRIBUTING.md) for details on how to get involved.
+
+Issues are tracked in GitHub and tagged with milestone information. For current development priorities, see our [open issues](https://github.com/cloudwalk/hermes-mcp/issues).

--- a/mix.exs
+++ b/mix.exs
@@ -104,9 +104,11 @@ defmodule Hermes.MixProject do
         "pages/progress_tracking.md",
         "pages/logging.md",
         "pages/error_handling.md",
+        "pages/protocol_upgrade_2025_03_26.md",
         "README.md",
         "CHANGELOG.md",
         "CONTRIBUTING.md",
+        "ROADMAP.md",
         "LICENSE"
       ],
       groups_for_extras: [
@@ -121,7 +123,9 @@ defmodule Hermes.MixProject do
           "pages/logging.md"
         ],
         References: [
-          "pages/rfc.md"
+          "pages/rfc.md",
+          "ROADMAP.md",
+          "pages/protocol_upgrade_2025_03_26.md"
         ]
       ]
     ]

--- a/pages/protocol_upgrade_2025_03_26.md
+++ b/pages/protocol_upgrade_2025_03_26.md
@@ -1,0 +1,181 @@
+# MCP Protocol Upgrade Guide: 2024-11-05 to 2025-03-26
+
+This guide documents the major changes between MCP specification versions 2024-11-05 and 2025-03-26, 
+and outlines a roadmap for upgrading Hermes MCP to support the new version while maintaining 
+backward compatibility.
+
+## Protocol Version Comparison
+
+### Major Changes
+
+| Feature | 2024-11-05 | 2025-03-26 | Impact |
+|---------|------------|------------|--------|
+| Authorization | Not present | Comprehensive OAuth 2.1 based framework | Major addition |
+| HTTP Transport | HTTP+SSE (separate endpoints) | Streamable HTTP (single endpoint) | Breaking change |
+| Batching | Not supported | JSON-RPC batching supported | New capability |
+| Tool Annotations | Basic metadata | Comprehensive annotations (read-only, destructive, etc.) | Enhancement |
+| Audio Content | Not supported | Supported alongside text and image | New capability |
+| Progress Updates | Basic progress info | Added descriptive message field | Enhancement |
+| Completions | Implicit | Explicit capability | Enhancement |
+
+### Breaking Changes Details
+
+#### 1. Authorization Framework
+
+The 2025-03-26 specification introduces a comprehensive OAuth 2.1 based authorization framework including:
+
+- Server Metadata Discovery (RFC8414)
+- Dynamic Client Registration Protocol (RFC7591)
+- Session management via headers
+- Support for different OAuth grant types
+
+This primarily impacts HTTP-based transports and doesn't apply to STDIO connections.
+
+#### 2. Streamable HTTP Transport
+
+The new transport replaces separate SSE and HTTP endpoints with a single "MCP endpoint" that supports:
+
+- Both GET and POST methods
+- Response content negotiation
+- Session management via `Mcp-Session-Id` header
+- Stream resumability with the `Last-Event-ID` header
+
+This is a significant change to the transport layer architecture and requires careful implementation to maintain backward compatibility.
+
+#### 3. JSON-RPC Batching
+
+The 2025-03-26 specification adds support for JSON-RPC batching, allowing multiple requests to be sent and received in a single operation. This affects:
+
+- Message encoding/decoding
+- Request tracking
+- Error handling
+
+## Upgrading Roadmap
+
+### Phase 1: Preparation and Compatibility Layer
+
+1. **Implement Protocol Version Detection and Negotiation**
+   - Enhance `Hermes.Client` to handle multiple protocol versions
+   - Implement version-specific capabilities handling
+
+2. **Transport Layer Compatibility**
+   - Maintain `Hermes.Transport.SSE` for 2024-11-05
+   - Create new transport for 2025-03-26 Streamable HTTP protocol
+   - Ensure graceful backwards compatibility
+
+3. **Message Handling Updates**
+   - Update message handling to support both protocol versions
+   - Add structures to handle version-specific features
+
+### Phase 2: Core Feature Implementation
+
+1. **Implement Streamable HTTP Transport**
+   - Develop new transport implementation based on the spec
+   - Support both content types (application/json and text/event-stream)
+   - Implement session management
+   - Add stream resumability
+
+2. **Add Authorization Support**
+   - Implement OAuth 2.1 support for HTTP transport
+   - Add Server Metadata Discovery
+   - Support Dynamic Client Registration
+   - Handle token management and refresh
+
+3. **Add JSON-RPC Batching**
+   - Enhance Message module to handle batched messages
+   - Update client API to support batched operations
+   - Implement state tracking for batched requests
+
+4. **Implement Tool Annotations**
+   - Update tool handling to support detailed annotations
+   - Add helper functions for checking tool properties
+
+### Phase 3: API Enhancements and Documentation
+
+1. **Enhance Client API**
+   - Add explicit completions support
+   - Update progress notifications to include message field
+   - Support audio content type
+
+2. **Refine Backward Compatibility**
+   - Ensure seamless operation with both protocol versions
+   - Implement auto-detection where possible
+   - Add migration helpers
+
+3. **Update Documentation**
+   - Document new features and API changes
+   - Provide migration guides for users
+
+## API Impact Analysis
+
+### Minimal-Impact Changes
+
+These changes should have little or no impact on the existing API:
+
+- Tool annotations
+- Audio content
+- Message field for progress
+- Completions capability
+
+### Potential Breaking Changes
+
+#### Authorization
+
+The authorization flow will require new parameters and client setup:
+
+```elixir
+# Current client initialization
+Hermes.Client.start_link(
+  name: :mcp_client,
+  transport: [layer: Hermes.Transport.SSE],
+  client_info: %{"name" => "MyClient", "version" => "1.0.0"}
+)
+
+# With authorization (conceptual)
+Hermes.Client.start_link(
+  name: :mcp_client,
+  transport: [
+    layer: Hermes.Transport.HTTP,
+    auth: [
+      client_id: "client_id",
+      redirect_uri: "http://localhost:8000/callback",
+      auth_callback: &MyApp.handle_auth_flow/1
+    ]
+  ],
+  client_info: %{"name" => "MyClient", "version" => "1.0.0"}
+)
+```
+
+#### Transport Layer
+
+Users explicitly using `Hermes.Transport.SSE` will need to update to the new transport or use a compatibility mechanism.
+
+### Backward Compatibility Considerations
+
+1. **Protocol Version Negotiation**
+   - Allow clients to specify preferred protocol versions
+   - Automatically negotiate based on server capabilities
+   - Fallback gracefully to supported versions
+
+2. **Transport Abstraction**
+   - Keep transport implementation details internal where possible
+   - Use polymorphic behavior through protocols or behaviors
+
+3. **Gradual Deprecation Path**
+   - Mark 2024-11-05 specific features as deprecated
+   - Provide clear migration path in documentation
+   - Eventually remove deprecated features in a future major version
+
+## Conclusion
+
+The upgrade to MCP 2025-03-26 introduces significant changes, particularly around transport and authorization. 
+By using a phased approach with careful abstractions, we can implement these changes while maintaining 
+backward compatibility.
+
+The most challenging aspects will be:
+
+1. Supporting both transport models simultaneously
+2. Implementing the OAuth flow in a user-friendly way
+3. Managing the increased complexity of version-specific code paths
+
+This document will be updated as implementation progresses with more specific details and examples.


### PR DESCRIPTION
## Problem

The README didn't clearly communicate that Hermes MCP aims to be a complete SDK for
 both client and server implementations. Additionally, the project lacked a
comprehensive roadmap detailing future development plans and the strategy for
implementing MCP 2025-03-26 specification.

## Solution

- Updated README to clarify Hermes MCP's scope as a complete Elixir SDK for MCP
- Reorganized roadmap in README into "Current Status" and "Upcoming" sections
- Added information about MCP 2025-03-26 support plans
- Created detailed ROADMAP.md document with milestones and timelines
- Added documentation about protocol upgrade plans in pages/protocol_upgrade_2025_03_26.md

## Rationale

These documentation improvements help users and potential contributors better
understand:
1. The complete scope of the project (both client and server)
2. Current implementation status
3. Planned features and implementation strategy for MCP 2025-03-26
4. Expected development timeline and priorities

Having separate documents for different levels of detail (overview in README,
comprehensive plan in ROADMAP.md, and technical details in protocol_upgrade doc) 
provides appropriate information for different audiences.
