### PR TITLE
fix: client reinitialization from interactive cli

### DIFF
--- a/lib/mix/interactive/commands.ex
+++ b/lib/mix/interactive/commands.ex
@@ -2,7 +2,7 @@ defmodule Mix.Interactive.Commands do
   @moduledoc """
   Common command implementations for interactive MCP shells.
 
-  This module contains the implementation of all commands available in the 
+  This module contains the implementation of all commands available in the
   interactive MCP shells. It provides a consistent set of commands across
   different transport implementations, with shared functionality for:
 
@@ -217,7 +217,7 @@ defmodule Mix.Interactive.Commands do
   defp initialize_client(client, loop_fn) do
     IO.puts("\n#{UI.colors().info}Reinitializing client connection...#{UI.colors().reset}")
 
-    send(client, :initialize)
+    GenServer.cast(client, :initialize)
     Process.flag(:trap_exit, true)
     :timer.sleep(500)
 


### PR DESCRIPTION
## Problem
Client process fails due to message sent from cli process isn't handled properly by GenServer when using `initialize` command of the interactive cli.

![Screenshot of the error](https://github.com/user-attachments/assets/1ab619c9-42bb-469c-ae98-df8f3c82f9c6)

## Solution
Call `GenServer.cast(client, :initialize)` instead of `send(client, :initialize)`

![Screenshot of the output when the solution is implemented](https://github.com/user-attachments/assets/2405fc45-8de1-41c7-b7f0-7ec737ca404a)

## Rationale
Client process is a GenServer, which handles `:initialize` messages asynchronously in `handle_cast/2` implementation. However, the mix task process sends the message synchronously with `send/2`, causing the client process to terminate. The solution would be either handle synchronous call as well for the message in GenServer, or call it always asynchronously. I believe it was meant to be async call when looking at the rest of the code block.
