### PR TITLE
fix: use mix.lock as cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,28 +110,20 @@ jobs:
         if: steps.build-cache.outputs.cache-hit != 'true'
         run: mix deps.compile --warnings-as-errors
 
-      # Don't cache PLTs based on mix.lock hash, as Dialyzer can incrementally update even old ones
-      # Cache key based on Elixir & Erlang version (also useful when running in matrix)
-      - name: Restore PLT cache
-        uses: actions/cache/restore@v3
+      # Cache PLTs based on Elixir & Erlang version + mix.lock hash
+      - name: Restore/Save PLT cache
+        uses: actions/cache@v4
         id: plt_cache
         with:
-          key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-plt
-          restore-keys: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-plt
           path: priv/plts
+          key: ${{ runner.os }}-plt-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
+          restore-keys: |
+            ${{ runner.os }}-plt-${{ matrix.otp }}-${{ matrix.elixir }}-
 
       # Create PLTs if no cache was found
       - name: Create PLTs
         if: steps.plt_cache.outputs.cache-hit != 'true'
         run: mix dialyzer --plt
-
-      - name: Save PLT cache
-        uses: actions/cache/save@v3
-        if: steps.plt_cache.outputs.cache-hit != 'true'
-        id: plt_cache_save
-        with:
-          key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-plt
-          path: priv/plts
 
       - name: Run dialyzer
         run: mix dialyzer --format github


### PR DESCRIPTION
## Problem

Dialyzer PLT cache in CI workflow was being reset on every run, taking ~2 minutes
each time instead of using cached results.

## Solution

Fixed the GitHub Actions cache configuration for dialyzer PLTs by:
1. Using a single cache action instead of separate restore/save steps
2. Including mix.lock hash in the cache key for proper dependency tracking
3. Adding better restore-keys fallback pattern

## Rationale

The previous implementation had issues with:
- Using separate restore/save actions (v3) rather than the simpler combined cache
action (v4)
- Not including dependency changes in the cache key
- Lack of fallback restore keys for partial matches

This implementation follows GitHub Actions best practices for caching and should
significantly speed up CI runs.
