### PR TITLE
Properly merge endpoint url

### DIFF
--- a/lib/hermes/transport/sse.ex
+++ b/lib/hermes/transport/sse.ex
@@ -181,8 +181,8 @@ defmodule Hermes.Transport.SSE do
   @impl GenServer
   def handle_info({:endpoint, endpoint}, %{client: client, server_url: server_url} = state) do
     GenServer.cast(client, :initialize)
-    message_url = HermesURI.join_path(server_url, endpoint)
-    {:noreply, %{state | message_url: message_url}}
+    msg_url = URI.merge(URI.parse(server_url), endpoint)
+    {:noreply, %{state | message_url: to_string(msg_url)}}
   end
 
   def handle_info({:message, message}, %{client: client} = state) do


### PR DESCRIPTION
## Problem

It is actually valid for a sse mcp server to return a fully specified url for the message (there technically ought to be host validation too).  This was not being implemented with the naive path merge currently done

## Solution

Simply use https://hexdocs.pm/elixir/1.13/URI.html#merge/2 which handles this in an RFC-compliant way

## Rationale

don't want to reinvent the wheel