### PR TITLE
Genserver timeout opt

### DIFF
--- a/lib/hermes/client.ex
+++ b/lib/hermes/client.ex
@@ -271,6 +271,7 @@ defmodule Hermes.Client do
   ## Options
 
     * `:timeout` - Request timeout in milliseconds
+    * `:genserver_timeout` - GenServer.call/3 timeout in milliseconds (default: 5s)
     * `:progress` - Progress tracking options
       * `:token` - A unique token to track progress (string or integer)
       * `:callback` - A function to call when progress updates are received
@@ -289,7 +290,9 @@ defmodule Hermes.Client do
         timeout: Keyword.get(opts, :timeout)
       })
 
-    GenServer.call(client, {:operation, operation})
+    genserver_timeout = Keyword.get(opts, :genserver_timeout, 5_000)
+
+    GenServer.call(client, {:operation, operation}, genserver_timeout)
   end
 
   @doc """

--- a/lib/hermes/client.ex
+++ b/lib/hermes/client.ex
@@ -141,6 +141,7 @@ defmodule Hermes.Client do
 
     * `:cursor` - Pagination cursor for continuing a previous request
     * `:timeout` - Request timeout in milliseconds
+    * `:genserver_timeout` - GenServer.call/3 timeout in milliseconds (default: 5s)
     * `:progress` - Progress tracking options
       * `:token` - A unique token to track progress (string or integer)
       * `:callback` - A function to call when progress updates are received
@@ -158,7 +159,9 @@ defmodule Hermes.Client do
         timeout: Keyword.get(opts, :timeout)
       })
 
-    GenServer.call(client, {:operation, operation})
+    genserver_timeout = Keyword.get(opts, :genserver_timeout, 5_000)
+
+    GenServer.call(client, {:operation, operation}, genserver_timeout)
   end
 
   @doc """
@@ -167,6 +170,7 @@ defmodule Hermes.Client do
   ## Options
 
     * `:timeout` - Request timeout in milliseconds
+    * `:genserver_timeout` - GenServer.call/3 timeout in milliseconds (default: 5s)
     * `:progress` - Progress tracking options
       * `:token` - A unique token to track progress (string or integer)
       * `:callback` - A function to call when progress updates are received
@@ -181,7 +185,9 @@ defmodule Hermes.Client do
         timeout: Keyword.get(opts, :timeout)
       })
 
-    GenServer.call(client, {:operation, operation})
+    genserver_timeout = Keyword.get(opts, :genserver_timeout, 5_000)
+
+    GenServer.call(client, {:operation, operation}, genserver_timeout)
   end
 
   @doc """
@@ -191,6 +197,7 @@ defmodule Hermes.Client do
 
     * `:cursor` - Pagination cursor for continuing a previous request
     * `:timeout` - Request timeout in milliseconds
+    * `:genserver_timeout` - GenServer.call/3 timeout in milliseconds (default: 5s)
     * `:progress` - Progress tracking options
       * `:token` - A unique token to track progress (string or integer)
       * `:callback` - A function to call when progress updates are received
@@ -208,7 +215,9 @@ defmodule Hermes.Client do
         timeout: Keyword.get(opts, :timeout)
       })
 
-    GenServer.call(client, {:operation, operation})
+    genserver_timeout = Keyword.get(opts, :genserver_timeout, 5_000)
+
+    GenServer.call(client, {:operation, operation}, genserver_timeout)
   end
 
   @doc """
@@ -217,6 +226,7 @@ defmodule Hermes.Client do
   ## Options
 
     * `:timeout` - Request timeout in milliseconds
+    * `:genserver_timeout` - GenServer.call/3 timeout in milliseconds (default: 5s)
     * `:progress` - Progress tracking options
       * `:token` - A unique token to track progress (string or integer)
       * `:callback` - A function to call when progress updates are received
@@ -235,7 +245,9 @@ defmodule Hermes.Client do
         timeout: Keyword.get(opts, :timeout)
       })
 
-    GenServer.call(client, {:operation, operation})
+    genserver_timeout = Keyword.get(opts, :genserver_timeout, 5_000)
+
+    GenServer.call(client, {:operation, operation}, genserver_timeout)
   end
 
   @doc """
@@ -245,6 +257,7 @@ defmodule Hermes.Client do
 
     * `:cursor` - Pagination cursor for continuing a previous request
     * `:timeout` - Request timeout in milliseconds
+    * `:genserver_timeout` - GenServer.call/3 timeout in milliseconds (default: 5s)
     * `:progress` - Progress tracking options
       * `:token` - A unique token to track progress (string or integer)
       * `:callback` - A function to call when progress updates are received
@@ -262,7 +275,9 @@ defmodule Hermes.Client do
         timeout: Keyword.get(opts, :timeout)
       })
 
-    GenServer.call(client, {:operation, operation})
+    genserver_timeout = Keyword.get(opts, :genserver_timeout, 5_000)
+
+    GenServer.call(client, {:operation, operation}, genserver_timeout)
   end
 
   @doc """

--- a/test/hermes/client_test.exs
+++ b/test/hermes/client_test.exs
@@ -345,14 +345,17 @@ defmodule Hermes.ClientTest do
         decoded = JSON.decode!(message)
         assert decoded["method"] == "tools/call"
         assert decoded["params"] == %{"name" => "test_tool"}
-        Process.sleep(200) # Simulate slow response
+        # Simulate slow response
+        Process.sleep(200)
         :ok
       end)
 
       Process.flag(:trap_exit, true)
-      {pid, ref} = spawn_monitor(fn ->
-        Hermes.Client.call_tool(client, "test_tool", nil, genserver_timeout: 100)
-      end)
+
+      {pid, ref} =
+        spawn_monitor(fn ->
+          Hermes.Client.call_tool(client, "test_tool", nil, genserver_timeout: 100)
+        end)
 
       # Wait for the process to die from timeout
       assert_receive {:DOWN, ^ref, :process, ^pid, _}, 300
@@ -371,9 +374,10 @@ defmodule Hermes.ClientTest do
         :ok
       end)
 
-      task = Task.async(fn ->
-        Hermes.Client.call_tool(client, "test_tool", nil, genserver_timeout: 7_000)
-      end)
+      task =
+        Task.async(fn ->
+          Hermes.Client.call_tool(client, "test_tool", nil, genserver_timeout: 7_000)
+        end)
 
       # Wait for the request_id to be sent from the mock
       request_id =

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -14,7 +14,29 @@ defmodule Hermes.MockTransportImpl do
   def shutdown(_), do: :ok
 end
 
+defmodule Hermes.SlowMockTransportImpl do
+  @moduledoc """
+  A mock transport implementation that simulates a transport which is slower than the default
+  gen server timeout (5s)
+  """
+  @behaviour Hermes.Transport
+
+  @impl true
+  def send_message(_pid, message) do
+    # Simulate a slow transport by sleeping
+    Process.sleep(6_000)
+    :ok
+  end
+
+  @impl true
+  def shutdown(_pid) do
+    :ok
+  end
+end
+
+
 Mox.defmock(Hermes.MockTransport, for: Hermes.Transport.Behaviour)
+Mox.defmock(Hermes.SlowMockTransport, for: Hermes.Transport.Behaviour)
 
 defmodule StubClient do
   @moduledoc false

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -14,30 +14,7 @@ defmodule Hermes.MockTransportImpl do
   def shutdown(_), do: :ok
 end
 
-defmodule Hermes.SlowMockTransportImpl do
-  @moduledoc """
-  A mock transport implementation that simulates a transport which is slower than the default
-  gen server timeout (5s)
-  """
-  @behaviour Hermes.Transport.Behaviour
-
-  @impl true
-  def start_link(_opts), do: {:ok, self()}
-
-  @impl true
-  def send_message(_pid, _message) do
-    # Simulate a slow transport by sleeping
-    Process.sleep(6_000)
-    :ok
-  end
-
-  @impl true
-  def shutdown(_pid), do: :ok
-end
-
-
 Mox.defmock(Hermes.MockTransport, for: Hermes.Transport.Behaviour)
-Mox.defmock(Hermes.SlowMockTransport, for: Hermes.Transport.Behaviour)
 
 defmodule StubClient do
   @moduledoc false

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -19,19 +19,20 @@ defmodule Hermes.SlowMockTransportImpl do
   A mock transport implementation that simulates a transport which is slower than the default
   gen server timeout (5s)
   """
-  @behaviour Hermes.Transport
+  @behaviour Hermes.Transport.Behaviour
 
   @impl true
-  def send_message(_pid, message) do
+  def start_link(_opts), do: {:ok, self()}
+
+  @impl true
+  def send_message(_pid, _message) do
     # Simulate a slow transport by sleeping
     Process.sleep(6_000)
     :ok
   end
 
   @impl true
-  def shutdown(_pid) do
-    :ok
-  end
+  def shutdown(_pid), do: :ok
 end
 
 


### PR DESCRIPTION
## Problem

For slow running STDIO servers I was hitting the Elixir default Genserver timeout of 5 seconds for `GenServer.call/3` 

## Solution

Adds the option of a `genserver_timeout` to some of the key Client operations. 

## Rationale

The key function I need the timeout for is `call_tool/3`, but I've added the same configuration to the other functions which have the possibility of taking some time to complete. 

## Testing

The slow MCP server in question was [the Perplexity Ask MCP](https://github.com/ppl-ai/modelcontextprotocol)
