### PR TITLE
feat: improve log handling on core lib and interactive/cli

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,2 +1,6 @@
+if [ -f .env.local ]; then
+	source .env.local;
+fi
+
 export HERMES_MCP_COMPILE_CLI=true
 export MIX_ENV=prod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,15 +110,19 @@ jobs:
         if: steps.build-cache.outputs.cache-hit != 'true'
         run: mix deps.compile --warnings-as-errors
 
+      # Ensure PLTs directory exists
+      - name: Create PLTs directory
+        run: mkdir -p priv/plts
+
       # Cache PLTs based on Elixir & Erlang version + mix.lock hash
       - name: Restore/Save PLT cache
         uses: actions/cache@v4
         id: plt_cache
         with:
           path: priv/plts
-          key: ${{ runner.os }}-plt-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
+          key: plt-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('mix.lock') }}
           restore-keys: |
-            ${{ runner.os }}-plt-${{ matrix.otp }}-${{ matrix.elixir }}-
+            plt-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-
 
       # Create PLTs if no cache was found
       - name: Create PLTs

--- a/config/config.exs
+++ b/config/config.exs
@@ -8,4 +8,4 @@ config :hermes_mcp, compile_cli?: boolean.("HERMES_MCP_COMPILE_CLI")
 
 config :logger, :default_formatter,
   format: "[$level] $message $metadata\n",
-  metadata: [:module, :mcp_client, :mcp_transport]
+  metadata: [:module, :mcp_client, :mcp_client_name, :mcp_transport]

--- a/lib/hermes/http.ex
+++ b/lib/hermes/http.ex
@@ -42,7 +42,11 @@ defmodule Hermes.HTTP do
   defp do_follow_redirect(req, %Finch.Response{status: 307, headers: headers}, attempts) when is_integer(attempts) do
     location = List.keyfind(headers, "location", 0)
 
-    Logger.debug("Following redirect to: #{location}, attempts left: #{attempts}")
+    Hermes.Logging.transport_event("redirect", %{
+      location: location,
+      attempts_left: attempts,
+      method: req.method
+    })
 
     {:ok, uri} = URI.new(location)
     req = %{req | host: uri.host, port: uri.port, path: uri.path, scheme: uri.scheme}

--- a/lib/hermes/logging.ex
+++ b/lib/hermes/logging.ex
@@ -1,0 +1,130 @@
+defmodule Hermes.Logging do
+  @moduledoc """
+  Centralized logging for Hermes MCP client.
+
+  This module provides structured logging functions that automatically manage context
+  and format logs appropriately based on log levels.
+  """
+
+  require Logger
+
+  @doc """
+  Log protocol messages with automatic formatting and context.
+
+  ## Parameters
+    * direction - "incoming" or "outgoing"
+    * type - message type (e.g., "request", "response", "notification", "error")
+    * id - message ID (can be nil)
+    * data - the message content
+    * metadata - additional metadata to include
+  """
+  def message(direction, type, id, data, metadata \\ []) do
+    summary = create_message_summary(type, id, data)
+
+    Logger.debug("[MCP message] #{direction} #{type}: #{summary}", metadata)
+
+    if should_log_details?(data) do
+      Logger.debug("[MCP message] #{direction} #{type} data: #{inspect(data)}", metadata)
+    else
+      Logger.debug("[MCP message] #{direction} #{type} data (truncated): #{truncate_data(data)}", metadata)
+    end
+  end
+
+  @doc """
+  Log server events with structured format.
+  """
+  def server_event(event, details, metadata \\ []) do
+    Logger.info("MCP server event: #{event}", metadata)
+
+    if details do
+      Logger.debug("MCP event details: #{inspect(details)}", metadata)
+    end
+  end
+
+  @doc """
+  Log client events with structured format.
+  """
+  def client_event(event, details, metadata \\ []) do
+    Logger.info("MCP client event: #{event}", metadata)
+
+    if details do
+      Logger.debug("MCP event details: #{inspect(details)}", metadata)
+    end
+  end
+
+  @doc """
+  Log transport events with structured format.
+  """
+  def transport_event(event, details, metadata \\ []) do
+    Logger.debug("MCP transport event: #{event}", metadata)
+
+    if details do
+      Logger.debug("MCP transport details: #{inspect(details)}", metadata)
+    end
+  end
+
+  @doc """
+  Set context for all subsequent logs in the current process.
+  """
+  def context(metadata) when is_list(metadata) do
+    Logger.metadata(metadata)
+  end
+
+  @doc """
+  Add context to existing metadata for all subsequent logs.
+  """
+  def add_context(metadata) when is_list(metadata) do
+    Logger.metadata(Keyword.merge(Logger.metadata(), metadata))
+  end
+
+  # Private helpers
+
+  defp create_message_summary("request", id, data) when is_map(data) do
+    method = Map.get(data, "method", "unknown")
+    "id=#{id || "none"} method=#{method}"
+  end
+
+  defp create_message_summary("response", id, data) when is_map(data) do
+    result_summary =
+      cond do
+        Map.has_key?(data, "result") -> "success"
+        Map.has_key?(data, "error") -> "error: #{get_in(data, ["error", "code"])}"
+        true -> "unknown"
+      end
+
+    "id=#{id || "none"} #{result_summary}"
+  end
+
+  defp create_message_summary("notification", _id, data) when is_map(data) do
+    method = Map.get(data, "method", "unknown")
+    "method=#{method}"
+  end
+
+  defp create_message_summary(_type, id, _data) do
+    "id=#{id || "none"}"
+  end
+
+  defp should_log_details?(data) when is_binary(data), do: byte_size(data) < 500
+  defp should_log_details?(data) when is_map(data), do: map_size(data) < 10
+  defp should_log_details?(_), do: true
+
+  defp truncate_data(data) when is_binary(data), do: "#{String.slice(data, 0, 100)}..."
+
+  defp truncate_data(data) when is_map(data) do
+    important_keys =
+      case data do
+        %{"id" => _, "method" => _} -> ["id", "method"]
+        %{"id" => _, "result" => _} -> ["id"]
+        %{"id" => _, "error" => _} -> ["id", "error"]
+        %{"method" => _} -> ["method"]
+        _ -> Enum.take(Map.keys(data), 3)
+      end
+
+    data
+    |> Map.take(important_keys)
+    |> inspect()
+    |> Kernel.<>("...")
+  end
+
+  defp truncate_data(data), do: inspect(data, limit: 5)
+end

--- a/lib/hermes/sse.ex
+++ b/lib/hermes/sse.ex
@@ -105,7 +105,8 @@ defmodule Hermes.SSE do
   defp process_task_stream({ref, _task} = state) do
     receive do
       {:chunk, {:data, data}, ^ref} ->
-        Logger.debug("Received sse streaming data chunk")
+        # Only log this at trace level - too verbose for debug
+        # Logger.debug("Received sse streaming data chunk")
         {Parser.run(data), state}
 
       {:chunk, {:status, status}, ^ref} ->

--- a/lib/hermes/sse.ex
+++ b/lib/hermes/sse.ex
@@ -75,18 +75,40 @@ defmodule Hermes.SSE do
 
       case Finch.stream_while(req, Hermes.Finch, nil, on_chunk, http) do
         {:ok, _} ->
-          Logger.debug("SSE streaming closed with success, reconnecting...")
+          Hermes.Logging.transport_event("sse_reconnect", %{
+            reason: "success",
+            attempt: attempt,
+            max_attempts: retry[:max_reconnections]
+          })
+
           Process.sleep(backoff)
           loop_sse_stream(req, ref, dest, opts, attempt + 1)
 
         {:error, err} ->
-          Logger.error("SSE streaming closed with reason: #{inspect(err)}, reconnecting...")
+          Hermes.Logging.transport_event(
+            "sse_reconnect",
+            %{
+              reason: "error",
+              error: err,
+              attempt: attempt,
+              max_attempts: retry[:max_reconnections]
+            },
+            level: :error
+          )
+
           Process.sleep(backoff + to_timeout(second: 1))
           loop_sse_stream(req, ref, dest, opts, attempt + 1)
       end
     else
       send(dest, {:chunk, :halted, ref})
-      Logger.error("Max SSE streaming reconnection attempts achieved, giving up...")
+
+      Hermes.Logging.transport_event(
+        "sse_max_reconnects",
+        %{
+          max_attempts: retry[:max_reconnections]
+        },
+        level: :error
+      )
     end
   end
 
@@ -105,24 +127,22 @@ defmodule Hermes.SSE do
   defp process_task_stream({ref, _task} = state) do
     receive do
       {:chunk, {:data, data}, ^ref} ->
-        # Only log this at trace level - too verbose for debug
-        # Logger.debug("Received sse streaming data chunk")
         {Parser.run(data), state}
 
       {:chunk, {:status, status}, ^ref} ->
-        Logger.debug("Received sse streaming status #{status}")
+        Hermes.Logging.transport_event("sse_status", status)
         {[], state}
 
-      {:chunk, {:headers, _headers}, ^ref} ->
-        Logger.debug("Received sse streaming headers")
+      {:chunk, {:headers, headers}, ^ref} ->
+        Hermes.Logging.transport_event("sse_headers", headers)
         {[], state}
 
       {:chunk, :halted, ^ref} ->
-        Logger.debug("SSE streaming halted, transport will try to restart")
+        Hermes.Logging.transport_event("sse_halted", "Transport will be restarted")
         {[{:error, :halted}], state}
 
       {:chunk, unknown, ^ref} ->
-        Logger.debug("Received unknonw chunk: #{inspect(unknown)}")
+        Hermes.Logging.transport_event("sse_unknown_chunk", unknown)
         {[], state}
     end
   end

--- a/lib/hermes/transport/sse.ex
+++ b/lib/hermes/transport/sse.ex
@@ -16,11 +16,10 @@ defmodule Hermes.Transport.SSE do
   import Peri
 
   alias Hermes.HTTP
+  alias Hermes.Logging
   alias Hermes.SSE
   alias Hermes.SSE.Event
   alias Hermes.Transport.Behaviour, as: Transport
-
-  require Logger
 
   @type t :: GenServer.server()
 
@@ -116,7 +115,7 @@ defmodule Hermes.Transport.SSE do
 
     task =
       Task.async(fn ->
-        Logger.metadata(parent_metadata)
+        Logging.context(parent_metadata)
 
         stream =
           SSE.connect(state.sse_url, state.headers,
@@ -138,36 +137,24 @@ defmodule Hermes.Transport.SSE do
   end
 
   defp handle_sse_event({:error, :halted}, pid) do
-    Logger.debug("Received halt notification from SSE streaming, transport will be restarted")
+    Hermes.Logging.transport_event("sse_halted", "Transport will be restarted")
     shutdown(pid)
   end
 
   defp handle_sse_event(%Event{event: "endpoint", data: endpoint}, pid) do
-    Logger.debug("Received endpoint event from server")
+    Hermes.Logging.transport_event("endpoint", endpoint)
     send(pid, {:endpoint, endpoint})
   end
 
   defp handle_sse_event(%Event{event: "message", data: data}, pid) do
-    Logger.debug("Received message event from server")
-
-    if String.length(data) < 500 do
-      Logger.debug("Message data: #{data}")
-    else
-      Logger.debug("Message data (truncated): #{String.slice(data, 0, 100)}...")
-    end
-
+    Hermes.Logging.transport_event("message", data)
     send(pid, {:message, data})
   end
 
   # coming from fast-mcp ruby
   # https://github.com/yjacquin/fast-mcp/issues/38
   defp handle_sse_event(%Event{event: "ping", data: data}, _) do
-    Logger.debug("Received SSE ping event from server")
-    Logger.debug("Ping event data: #{data}")
-  end
-
-  defp handle_sse_event(%Event{event: "ping"}, _) do
-    Logger.debug("Received empty SSE ping event from server")
+    Hermes.Logging.transport_event("ping", data)
   end
 
   defp handle_sse_event(%Event{event: "reconnect", data: data}, _pid) do
@@ -177,12 +164,11 @@ defmodule Hermes.Transport.SSE do
         _ -> "unknown"
       end
 
-    Logger.debug("Received SSE reconnect event from server: #{reason}, connection will be refreshed")
-    Logger.debug("Reconnect event data: #{data}")
+    Hermes.Logging.transport_event("reconnect", %{reason: reason, data: data})
   end
 
   defp handle_sse_event(event, _pid) do
-    Logger.warning("Unhandled SSE event from stream: #{inspect(event)}")
+    Hermes.Logging.transport_event("unknown", event, level: :warning)
   end
 
   @impl GenServer
@@ -198,7 +184,7 @@ defmodule Hermes.Transport.SSE do
         {:reply, :ok, state}
 
       {:ok, %Finch.Response{status: status, body: body}} ->
-        Logger.error("HTTP error: #{status}, #{body}")
+        Logging.transport_event("http_error", %{status: status, body: body}, level: :error)
         {:reply, {:error, {:http_error, status, body}}, state}
 
       {:error, reason} ->
@@ -224,12 +210,12 @@ defmodule Hermes.Transport.SSE do
   end
 
   def handle_info({:DOWN, _ref, :process, pid, reason}, %{stream_task: %Task{pid: pid}} = state) do
-    Logger.error("SSE stream task terminated: #{inspect(reason)}")
+    Logging.transport_event("stream_terminated", %{reason: reason}, level: :error)
     {:stop, {:stream_terminated, reason}, state}
   end
 
   def handle_info(msg, state) do
-    Logger.debug("Unexpected genserver message: #{inspect(msg)}")
+    Logging.transport_event("unexpected_message", %{message: msg})
     {:noreply, state}
   end
 

--- a/lib/hermes/transport/sse.ex
+++ b/lib/hermes/transport/sse.ex
@@ -149,13 +149,25 @@ defmodule Hermes.Transport.SSE do
 
   defp handle_sse_event(%Event{event: "message", data: data}, pid) do
     Logger.debug("Received message event from server")
+
+    if String.length(data) < 500 do
+      Logger.debug("Message data: #{data}")
+    else
+      Logger.debug("Message data (truncated): #{String.slice(data, 0, 100)}...")
+    end
+
     send(pid, {:message, data})
   end
 
   # coming from fast-mcp ruby
   # https://github.com/yjacquin/fast-mcp/issues/38
-  defp handle_sse_event(%Event{event: "ping"}, _) do
+  defp handle_sse_event(%Event{event: "ping", data: data}, _) do
     Logger.debug("Received SSE ping event from server")
+    Logger.debug("Ping event data: #{data}")
+  end
+
+  defp handle_sse_event(%Event{event: "ping"}, _) do
+    Logger.debug("Received empty SSE ping event from server")
   end
 
   defp handle_sse_event(%Event{event: "reconnect", data: data}, _pid) do
@@ -166,6 +178,7 @@ defmodule Hermes.Transport.SSE do
       end
 
     Logger.debug("Received SSE reconnect event from server: #{reason}, connection will be refreshed")
+    Logger.debug("Reconnect event data: #{data}")
   end
 
   defp handle_sse_event(event, _pid) do

--- a/lib/hermes/transport/stdio.ex
+++ b/lib/hermes/transport/stdio.ex
@@ -121,28 +121,28 @@ defmodule Hermes.Transport.STDIO do
 
   @impl GenServer
   def handle_info({port, {:data, data}}, %{port: port} = state) do
-    Logger.info("Received data from stdio server")
+    Hermes.Logging.transport_event("stdio_received", String.slice(data, 0, 100))
     GenServer.cast(state.client, {:response, data})
     {:noreply, state}
   end
 
   def handle_info({port, :closed}, %{port: port} = state) do
-    Logger.warning("stdio server closed connection, restarting")
+    Hermes.Logging.transport_event("stdio_closed", "Connection closed, transport will restart", level: :warning)
     {:stop, :normal, state}
   end
 
   def handle_info({port, {:exit_status, status}}, %{port: port} = state) do
-    Logger.warning("stdio server exited with status: #{status}")
+    Hermes.Logging.transport_event("stdio_exit", %{status: status}, level: :warning)
     {:stop, status, state}
   end
 
   def handle_info({:DOWN, ref, :port, port, reason}, %{ref: ref, port: port} = state) do
-    Logger.error("stdio server monitor DOWN: #{inspect(reason)}")
+    Hermes.Logging.transport_event("stdio_down", %{reason: reason}, level: :error)
     {:stop, reason, state}
   end
 
   def handle_info({:EXIT, port, reason}, %{port: port} = state) do
-    Logger.error("stdio server exited: #{inspect(reason)}")
+    Hermes.Logging.transport_event("stdio_exit", %{reason: reason}, level: :error)
     {:stop, reason, state}
   end
 

--- a/lib/mix/interactive/commands.ex
+++ b/lib/mix/interactive/commands.ex
@@ -26,6 +26,7 @@ defmodule Mix.Interactive.Commands do
 
   @commands %{
     "help" => "Show this help message",
+    "ping" => "Send a ping to the server to check connection health",
     "list_tools" => "List server tools",
     "call_tool" => "Call a server tool with arguments",
     "list_prompts" => "List server prompts",
@@ -47,6 +48,7 @@ defmodule Mix.Interactive.Commands do
   Process a command entered by the user.
   """
   def process_command("help", _client, loop_fn), do: print_help(loop_fn)
+  def process_command("ping", client, loop_fn), do: ping_server(client, loop_fn)
   def process_command("list_tools", client, loop_fn), do: list_tools(client, loop_fn)
   def process_command("call_tool", client, loop_fn), do: call_tool(client, loop_fn)
   def process_command("list_prompts", client, loop_fn), do: list_prompts(client, loop_fn)
@@ -330,6 +332,21 @@ defmodule Mix.Interactive.Commands do
     IO.puts("\n#{UI.colors().info}Getting internal state information...#{UI.colors().reset}")
 
     State.print_state(client)
+
+    IO.puts("")
+    loop_fn.()
+  end
+
+  defp ping_server(client, loop_fn) do
+    IO.puts("\n#{UI.colors().info}Pinging server...#{UI.colors().reset}")
+
+    case Client.ping(client) do
+      :pong ->
+        IO.puts("#{UI.colors().success}✓ Pong! Server is responding#{UI.colors().reset}")
+
+      {:error, reason} ->
+        UI.print_error(reason)
+    end
 
     IO.puts("")
     loop_fn.()

--- a/lib/mix/tasks/sse.interactive.ex
+++ b/lib/mix/tasks/sse.interactive.ex
@@ -21,17 +21,25 @@ defmodule Mix.Tasks.Hermes.Sse.Interactive do
   @switches [
     base_url: :string,
     base_path: :string,
-    sse_path: :string
+    sse_path: :string,
+    verbose: :count
   ]
 
   def run(args) do
     # Start required applications without requiring a project
     Application.ensure_all_started([:hermes_mcp, :peri])
 
-    # Disable logger output to keep the UI clean
-    Logger.configure(level: :debug)
+    # Parse arguments and set log level
+    {parsed, _} =
+      OptionParser.parse!(args,
+        strict: @switches,
+        aliases: [v: :verbose]
+      )
 
-    {parsed, _} = OptionParser.parse!(args, strict: @switches)
+    verbose_count = parsed[:verbose] || 0
+    log_level = get_log_level(verbose_count)
+    configure_logger(log_level)
+
     server_options = Keyword.put_new(parsed, :base_url, "http://localhost:8000")
     server_url = Path.join(server_options[:base_url], server_options[:base_path] || "")
 
@@ -65,5 +73,21 @@ defmodule Mix.Tasks.Hermes.Sse.Interactive do
     IO.puts("\nType #{UI.colors().command}help#{UI.colors().reset} for available commands\n")
 
     Shell.loop(client)
+  end
+
+  # Helper functions
+  defp get_log_level(count) do
+    case count do
+      0 -> :error
+      1 -> :warning
+      2 -> :info
+      _ -> :debug
+    end
+  end
+
+  defp configure_logger(log_level) do
+    metadata = Logger.metadata()
+    Logger.configure(level: log_level)
+    Logger.metadata(metadata)
   end
 end

--- a/lib/mix/tasks/sse.interactive.ex
+++ b/lib/mix/tasks/sse.interactive.ex
@@ -29,7 +29,7 @@ defmodule Mix.Tasks.Hermes.Sse.Interactive do
     Application.ensure_all_started([:hermes_mcp, :peri])
 
     # Disable logger output to keep the UI clean
-    Logger.configure(level: :error)
+    Logger.configure(level: :debug)
 
     {parsed, _} = OptionParser.parse!(args, strict: @switches)
     server_options = Keyword.put_new(parsed, :base_url, "http://localhost:8000")

--- a/pages/cli_usage.md
+++ b/pages/cli_usage.md
@@ -63,6 +63,7 @@ Once connected, the CLI provides an interactive shell with several commands:
 | Command | Description |
 |---------|-------------|
 | `help` | Show list of available commands |
+| `ping` | Send a ping to the server to check connection health |
 | `list_tools` | List available server tools |
 | `call_tool` | Call a server tool with arguments |
 | `list_prompts` | List available server prompts |
@@ -107,6 +108,13 @@ mix hermes.sse.interactive --base-url=https://remote-server.example.com --verbos
 
 ```shell
 mix hermes.stdio.interactive --command=./my-mcp-server --args=arg1,arg2
+```
+
+### Checking Server Connection
+
+```
+mcp> ping
+# Shows if the server is responding with a pong
 ```
 
 ### Calling a Tool

--- a/pages/cli_usage.md
+++ b/pages/cli_usage.md
@@ -39,7 +39,11 @@ Both CLIs support the following common options:
 | Option | Description |
 |--------|-------------|
 | `-h, --help` | Show help message and exit |
-| `-v, --verbose` | Enable verbose output and detailed error information |
+| `-v` | Set log level (accumulating flag) |
+|      | No flag: `:error` level (default) |
+|      | `-v`: `:warning` level |
+|      | `-vv`: `:info` level |
+|      | `-vvv`: `:debug` level |
 
 ### SSE Transport Options
 
@@ -132,11 +136,23 @@ Tool arguments (JSON): {"operation": "+", "a": 1, "b": 2}
 ### Advanced Debugging
 
 ```shell
-# Enable verbose mode
-HERMES_VERBOSE=1 mix hermes.sse.interactive
+# Basic error-only logging (default)
+mix hermes.sse.interactive
 
-# Or use the command-line flag
+# Warning-level logging
 mix hermes.sse.interactive -v
+
+# Info-level logging
+mix hermes.sse.interactive -vv
+
+# Debug-level (most verbose) logging
+mix hermes.sse.interactive -vvv
 ```
 
-Then use the `show_state` command to see detailed internal state information, or examine extended error information when initialization fails.
+The verbosity level controls which log messages are displayed:
+- Default (no flags): Only errors are shown
+- `-v`: Errors and warnings are shown
+- `-vv`: Errors, warnings, and info messages are shown
+- `-vvv`: All messages including debug details are shown
+
+Use the `show_state` command to see detailed internal state information, or examine extended error information when initialization fails.


### PR DESCRIPTION
## Problem

Logging across the library lacked proper verbosity controls and didn't correctly
respect configured log levels, making it difficult to debug certain issues.

## Solution

- Added customizable log levels with proper semantics
- Implemented CLI verbose flags with accumulation (-v, -vv, -vvv)
- Fixed metadata preservation in all logger calls
- Updated documentation with usage examples

## Rationale

Command-line tools need flexible verbosity controls to aid in troubleshooting while
maintaining clean output by default. The accumulated verbose flag pattern (-v, -vv,
-vvv) provides an intuitive interface that's familiar to users.
