### PR TITLE
feat/client roots

### DIFF
--- a/lib/hermes/logging.ex
+++ b/lib/hermes/logging.ex
@@ -46,8 +46,7 @@ defmodule Hermes.Logging do
     log(level, "MCP server event: #{event}", metadata)
 
     if details do
-      details_level = if level == :debug, do: :debug, else: level
-      log(details_level, "MCP event details: #{inspect(details)}", metadata)
+      log(level, "MCP event details: #{inspect(details)}", metadata)
     end
   end
 
@@ -65,8 +64,7 @@ defmodule Hermes.Logging do
     log(level, "MCP client event: #{event}", metadata)
 
     if details do
-      details_level = if level == :debug, do: :debug, else: level
-      log(details_level, "MCP event details: #{inspect(details)}", metadata)
+      log(level, "MCP event details: #{inspect(details)}", metadata)
     end
   end
 

--- a/lib/hermes/mcp/message.ex
+++ b/lib/hermes/mcp/message.ex
@@ -9,7 +9,7 @@ defmodule Hermes.MCP.Message do
 
   # MCP message schemas
 
-  @request_methods ~w(initialize ping resources/list resources/read prompts/get prompts/list tools/call tools/list logging/setLevel completion/complete)
+  @request_methods ~w(initialize ping resources/list resources/read prompts/get prompts/list tools/call tools/list logging/setLevel completion/complete roots/list)
 
   @init_params_schema %{
     "protocolVersion" => {:required, :string},
@@ -100,6 +100,8 @@ defmodule Hermes.MCP.Message do
 
   defp parse_request_params_by_method(%{"method" => "completion/complete"}), do: {:ok, @completion_complete_params_schema}
 
+  defp parse_request_params_by_method(%{"method" => "roots/list"}), do: {:ok, :map}
+
   defp parse_request_params_by_method(_), do: {:ok, :map}
 
   @init_noti_params_schema :map
@@ -122,7 +124,8 @@ defmodule Hermes.MCP.Message do
     "jsonrpc" => {:required, {:string, {:eq, "2.0"}}},
     "method" =>
       {:required,
-       {:enum, ~w(notifications/initialized notifications/cancelled notifications/progress notifications/message)}},
+       {:enum,
+        ~w(notifications/initialized notifications/cancelled notifications/progress notifications/message notifications/roots/list_changed)}},
     "params" => {:dependent, &parse_notification_params_by_method/1}
   }
 
@@ -137,6 +140,8 @@ defmodule Hermes.MCP.Message do
 
   defp parse_notification_params_by_method(%{"method" => "notifications/message"}),
     do: {:ok, @logging_message_notif_params_schema}
+
+  defp parse_notification_params_by_method(%{"method" => "notifications/roots/list_changed"}), do: {:ok, :map}
 
   defp parse_notification_params_by_method(_), do: {:ok, :map}
 

--- a/lib/hermes/mcp/message.ex
+++ b/lib/hermes/mcp/message.ex
@@ -54,6 +54,7 @@ defmodule Hermes.MCP.Message do
     "level" => {:required, {:enum, @log_levels}}
   }
 
+
   @completion_prompt_ref_schema %{
     "type" => {:required, {:string, {:eq, "ref/prompt"}}},
     "name" => {:required, :string}

--- a/lib/hermes/mcp/message.ex
+++ b/lib/hermes/mcp/message.ex
@@ -54,7 +54,6 @@ defmodule Hermes.MCP.Message do
     "level" => {:required, {:enum, @log_levels}}
   }
 
-
   @completion_prompt_ref_schema %{
     "type" => {:required, {:string, {:eq, "ref/prompt"}}},
     "name" => {:required, :string}

--- a/lib/hermes/telemetry.ex
+++ b/lib/hermes/telemetry.ex
@@ -74,4 +74,7 @@ defmodule Hermes.Telemetry do
 
   # Progress events
   def event_progress_update, do: [:progress, :update]
+
+  # Roots events
+  def event_client_roots, do: [:client, :roots]
 end

--- a/test/hermes/client_test.exs
+++ b/test/hermes/client_test.exs
@@ -47,7 +47,38 @@ defmodule Hermes.ClientTest do
   end
 
   describe "request methods" do
-    setup :setup_initialized_client
+    setup do
+      expect(Hermes.MockTransport, :send_message, 2, fn _, _message -> :ok end)
+
+      client =
+        start_supervised!(
+          {Hermes.Client,
+           transport: [layer: Hermes.MockTransport, name: Hermes.MockTransportImpl],
+           client_info: %{"name" => "TestClient", "version" => "1.0.0"}},
+          restart: :temporary
+        )
+
+      allow(Hermes.MockTransport, self(), client)
+
+      initialize_client(client)
+
+      assert request_id = get_request_id(client, "initialize")
+
+      init_response = %{
+        "id" => request_id,
+        "jsonrpc" => "2.0",
+        "result" => %{
+          "capabilities" => %{"resources" => %{}, "tools" => %{}, "prompts" => %{}, "completion" => %{"complete" => true}},
+          "serverInfo" => %{"name" => "TestServer", "version" => "1.0.0"},
+          "protocolVersion" => "2024-11-05"
+        }
+      }
+
+      send_response(client, init_response)
+      Process.sleep(50)
+
+      %{client: client}
+    end
 
     test "ping sends correct request", %{client: client} do
       expect(Hermes.MockTransport, :send_message, fn _, message ->
@@ -324,7 +355,39 @@ defmodule Hermes.ClientTest do
   end
 
   describe "non support request methods" do
-    setup :setup_client_with_limited_capabilities
+    setup do
+      expect(Hermes.MockTransport, :send_message, 2, fn _, _message -> :ok end)
+
+      client =
+        start_supervised!(
+          {Hermes.Client,
+           transport: [layer: Hermes.MockTransport, name: Hermes.MockTransportImpl],
+           client_info: %{"name" => "TestClient", "version" => "1.0.0"}},
+          restart: :temporary
+        )
+
+      allow(Hermes.MockTransport, self(), client)
+
+      initialize_client(client)
+
+      assert request_id = get_request_id(client, "initialize")
+
+      init_response = %{
+        "id" => request_id,
+        "jsonrpc" => "2.0",
+        "result" => %{
+          "capabilities" => %{"prompts" => %{}, "completion" => %{"complete" => true}},
+          "serverInfo" => %{"name" => "TestServer", "version" => "1.0.0"},
+          "protocolVersion" => "2024-11-05"
+        }
+      }
+
+      send_response(client, init_response)
+
+      Process.sleep(50)
+
+      %{client: client}
+    end
 
     test "ping sends correct request since it is always supported", %{client: client} do
       expect(Hermes.MockTransport, :send_message, fn _, message ->
@@ -358,7 +421,37 @@ defmodule Hermes.ClientTest do
   end
 
   describe "error handling" do
-    setup :setup_initialized_client
+    setup do
+      expect(Hermes.MockTransport, :send_message, 2, fn _, _message -> :ok end)
+
+      client =
+        start_supervised!(
+          {Hermes.Client,
+           transport: [layer: Hermes.MockTransport, name: Hermes.MockTransportImpl],
+           client_info: %{"name" => "TestClient", "version" => "1.0.0"}},
+          restart: :temporary
+        )
+
+      allow(Hermes.MockTransport, self(), client)
+
+      initialize_client(client)
+
+      assert request_id = get_request_id(client, "initialize")
+
+      init_response = %{
+        "id" => request_id,
+        "jsonrpc" => "2.0",
+        "result" => %{
+          "capabilities" => %{"resources" => %{}, "tools" => %{}, "completion" => %{}},
+          "serverInfo" => %{"name" => "TestServer", "version" => "1.0.0"},
+          "protocolVersion" => "2024-11-05"
+        }
+      }
+
+      send_response(client, init_response)
+
+      %{client: client}
+    end
 
     test "handles error response", %{client: client} do
       expect(Hermes.MockTransport, :send_message, fn _, message ->
@@ -428,7 +521,39 @@ defmodule Hermes.ClientTest do
   end
 
   describe "server information" do
-    setup :setup_initialized_client
+    setup do
+      expect(Hermes.MockTransport, :send_message, 2, fn _, _message -> :ok end)
+
+      client =
+        start_supervised!(
+          {Hermes.Client,
+           transport: [layer: Hermes.MockTransport, name: Hermes.MockTransportImpl],
+           client_info: %{"name" => "TestClient", "version" => "1.0.0"}},
+          restart: :temporary
+        )
+
+      allow(Hermes.MockTransport, self(), client)
+
+      initialize_client(client)
+
+      assert request_id = get_request_id(client, "initialize")
+
+      init_response = %{
+        "id" => request_id,
+        "jsonrpc" => "2.0",
+        "result" => %{
+          "capabilities" => %{"resources" => %{"subscribe" => true}, "tools" => %{}, "completion" => %{}},
+          "serverInfo" => %{"name" => "TestServer", "version" => "1.0.0"},
+          "protocolVersion" => "2024-11-05"
+        }
+      }
+
+      send_response(client, init_response)
+
+      Process.sleep(500)
+
+      %{client: client}
+    end
 
     test "get_server_capabilities returns server capabilities", %{client: client} do
       capabilities = Hermes.Client.get_server_capabilities(client)
@@ -449,7 +574,39 @@ defmodule Hermes.ClientTest do
   end
 
   describe "progress tracking" do
-    setup :setup_initialized_client
+    setup do
+      expect(Hermes.MockTransport, :send_message, 2, fn _, _message -> :ok end)
+
+      client =
+        start_supervised!(
+          {Hermes.Client,
+           transport: [layer: Hermes.MockTransport, name: Hermes.MockTransportImpl],
+           client_info: %{"name" => "TestClient", "version" => "1.0.0"}},
+          restart: :temporary
+        )
+
+      allow(Hermes.MockTransport, self(), client)
+
+      initialize_client(client)
+
+      assert request_id = get_request_id(client, "initialize")
+
+      init_response = %{
+        "id" => request_id,
+        "jsonrpc" => "2.0",
+        "result" => %{
+          "capabilities" => %{"resources" => %{}, "tools" => %{}, "prompts" => %{}, "completion" => %{"complete" => true}},
+          "serverInfo" => %{"name" => "TestServer", "version" => "1.0.0"},
+          "protocolVersion" => "2024-11-05"
+        }
+      }
+
+      send_response(client, init_response)
+
+      Process.sleep(50)
+
+      %{client: client}
+    end
 
     test "registers and calls progress callback when notification is received", %{client: client} do
       # Variables for progress tracking
@@ -537,7 +694,40 @@ defmodule Hermes.ClientTest do
   end
 
   describe "logging" do
-    setup :setup_initialized_client
+    setup do
+      expect(Hermes.MockTransport, :send_message, 2, fn _, _message -> :ok end)
+
+      client =
+        start_supervised!(
+          {Hermes.Client,
+           transport: [layer: Hermes.MockTransport, name: Hermes.MockTransportImpl],
+           client_info: %{"name" => "TestClient", "version" => "1.0.0"}},
+          restart: :temporary
+        )
+
+      allow(Hermes.MockTransport, self(), client)
+
+      # Initialize the client
+      initialize_client(client)
+
+      assert request_id = get_request_id(client, "initialize")
+
+      init_response = %{
+        "id" => request_id,
+        "jsonrpc" => "2.0",
+        "result" => %{
+          "capabilities" => %{"resources" => %{}, "tools" => %{}, "logging" => %{}, "completion" => %{"complete" => true}},
+          "serverInfo" => %{"name" => "TestServer", "version" => "1.0.0"},
+          "protocolVersion" => "2024-11-05"
+        }
+      }
+
+      send_response(client, init_response)
+
+      Process.sleep(50)
+
+      %{client: client}
+    end
 
     test "set_log_level sends the correct request", %{client: client} do
       expect(Hermes.MockTransport, :send_message, fn _, message ->
@@ -578,11 +768,20 @@ defmodule Hermes.ClientTest do
 
       Process.sleep(50)
 
-      request_id = get_request_id(client, "completion/complete")
-      assert request_id
+      assert request_id = get_request_id(client, "completion/complete")
 
-      values = ["python", "pytorch", "pyside"]
-      response = completion_complete_response(request_id, values, 3, false)
+      response = %{
+        "id" => request_id,
+        "jsonrpc" => "2.0",
+        "result" => %{
+          "completion" => %{
+            "values" => ["python", "pytorch", "pyside"],
+            "total" => 3,
+            "hasMore" => false
+          }
+        }
+      }
+
       send_response(client, response)
 
       assert {:ok, response} = Task.await(task)
@@ -590,7 +789,7 @@ defmodule Hermes.ClientTest do
 
       completion = Response.unwrap(response)["completion"]
       assert is_map(completion)
-      assert completion["values"] == values
+      assert completion["values"] == ["python", "pytorch", "pyside"]
       assert completion["total"] == 3
       assert completion["hasMore"] == false
     end
@@ -613,17 +812,26 @@ defmodule Hermes.ClientTest do
 
       Process.sleep(50)
 
-      request_id = get_request_id(client, "completion/complete")
-      assert request_id
+      assert request_id = get_request_id(client, "completion/complete")
 
-      values = ["utf-8", "utf-16"]
-      response = completion_complete_response(request_id, values, 2, false)
+      response = %{
+        "id" => request_id,
+        "jsonrpc" => "2.0",
+        "result" => %{
+          "completion" => %{
+            "values" => ["utf-8", "utf-16"],
+            "total" => 2,
+            "hasMore" => false
+          }
+        }
+      }
+
       send_response(client, response)
 
       assert {:ok, response} = Task.await(task)
 
       completion = Response.unwrap(response)["completion"]
-      assert completion["values"] == values
+      assert completion["values"] == ["utf-8", "utf-16"]
       assert completion["total"] == 2
       assert completion["hasMore"] == false
     end
@@ -693,8 +901,17 @@ defmodule Hermes.ClientTest do
 
       initialize_client(client)
 
-      request_id = get_request_id(client, "initialize")
-      assert request_id
+      assert request_id = get_request_id(client, "initialize")
+
+      init_response = %{
+        "id" => request_id,
+        "jsonrpc" => "2.0",
+        "result" => %{
+          "capabilities" => %{"completion" => %{}},
+          "serverInfo" => %{"name" => "TestServer", "version" => "1.0.0"},
+          "protocolVersion" => "2024-11-05"
+        }
+      }
 
       init_response = init_response(request_id, %{"completion" => %{}})
       send_response(client, init_response)
@@ -704,7 +921,39 @@ defmodule Hermes.ClientTest do
   end
 
   describe "cancellation" do
-    setup :setup_initialized_client
+    setup do
+      expect(Hermes.MockTransport, :send_message, 2, fn _, _message -> :ok end)
+
+      client =
+        start_supervised!(
+          {Hermes.Client,
+           transport: [layer: Hermes.MockTransport, name: Hermes.MockTransportImpl],
+           client_info: %{"name" => "TestClient", "version" => "1.0.0"}},
+          restart: :temporary
+        )
+
+      allow(Hermes.MockTransport, self(), client)
+
+      initialize_client(client)
+
+      assert request_id = get_request_id(client, "initialize")
+
+      init_response = %{
+        "id" => request_id,
+        "jsonrpc" => "2.0",
+        "result" => %{
+          "capabilities" => %{"resources" => %{}, "tools" => %{}, "completion" => %{}},
+          "serverInfo" => %{"name" => "TestServer", "version" => "1.0.0"},
+          "protocolVersion" => "2024-11-05"
+        }
+      }
+
+      send_response(client, init_response)
+
+      Process.sleep(50)
+
+      %{client: client}
+    end
 
     test "handles cancelled notification from server", %{client: client} do
       expect(Hermes.MockTransport, :send_message, fn _, message ->

--- a/test/hermes/client_test.exs
+++ b/test/hermes/client_test.exs
@@ -47,38 +47,7 @@ defmodule Hermes.ClientTest do
   end
 
   describe "request methods" do
-    setup do
-      expect(Hermes.MockTransport, :send_message, 2, fn _, _message -> :ok end)
-
-      client =
-        start_supervised!(
-          {Hermes.Client,
-           transport: [layer: Hermes.MockTransport, name: Hermes.MockTransportImpl],
-           client_info: %{"name" => "TestClient", "version" => "1.0.0"}},
-          restart: :temporary
-        )
-
-      allow(Hermes.MockTransport, self(), client)
-
-      initialize_client(client)
-
-      assert request_id = get_request_id(client, "initialize")
-
-      init_response = %{
-        "id" => request_id,
-        "jsonrpc" => "2.0",
-        "result" => %{
-          "capabilities" => %{"resources" => %{}, "tools" => %{}, "prompts" => %{}, "completion" => %{"complete" => true}},
-          "serverInfo" => %{"name" => "TestServer", "version" => "1.0.0"},
-          "protocolVersion" => "2024-11-05"
-        }
-      }
-
-      send_response(client, init_response)
-      Process.sleep(50)
-
-      %{client: client}
-    end
+    setup :setup_initialized_client
 
     test "ping sends correct request", %{client: client} do
       expect(Hermes.MockTransport, :send_message, fn _, message ->
@@ -355,39 +324,7 @@ defmodule Hermes.ClientTest do
   end
 
   describe "non support request methods" do
-    setup do
-      expect(Hermes.MockTransport, :send_message, 2, fn _, _message -> :ok end)
-
-      client =
-        start_supervised!(
-          {Hermes.Client,
-           transport: [layer: Hermes.MockTransport, name: Hermes.MockTransportImpl],
-           client_info: %{"name" => "TestClient", "version" => "1.0.0"}},
-          restart: :temporary
-        )
-
-      allow(Hermes.MockTransport, self(), client)
-
-      initialize_client(client)
-
-      assert request_id = get_request_id(client, "initialize")
-
-      init_response = %{
-        "id" => request_id,
-        "jsonrpc" => "2.0",
-        "result" => %{
-          "capabilities" => %{"prompts" => %{}, "completion" => %{"complete" => true}},
-          "serverInfo" => %{"name" => "TestServer", "version" => "1.0.0"},
-          "protocolVersion" => "2024-11-05"
-        }
-      }
-
-      send_response(client, init_response)
-
-      Process.sleep(50)
-
-      %{client: client}
-    end
+    setup :setup_client_with_limited_capabilities
 
     test "ping sends correct request since it is always supported", %{client: client} do
       expect(Hermes.MockTransport, :send_message, fn _, message ->
@@ -421,37 +358,7 @@ defmodule Hermes.ClientTest do
   end
 
   describe "error handling" do
-    setup do
-      expect(Hermes.MockTransport, :send_message, 2, fn _, _message -> :ok end)
-
-      client =
-        start_supervised!(
-          {Hermes.Client,
-           transport: [layer: Hermes.MockTransport, name: Hermes.MockTransportImpl],
-           client_info: %{"name" => "TestClient", "version" => "1.0.0"}},
-          restart: :temporary
-        )
-
-      allow(Hermes.MockTransport, self(), client)
-
-      initialize_client(client)
-
-      assert request_id = get_request_id(client, "initialize")
-
-      init_response = %{
-        "id" => request_id,
-        "jsonrpc" => "2.0",
-        "result" => %{
-          "capabilities" => %{"resources" => %{}, "tools" => %{}, "completion" => %{}},
-          "serverInfo" => %{"name" => "TestServer", "version" => "1.0.0"},
-          "protocolVersion" => "2024-11-05"
-        }
-      }
-
-      send_response(client, init_response)
-
-      %{client: client}
-    end
+    setup :setup_initialized_client
 
     test "handles error response", %{client: client} do
       expect(Hermes.MockTransport, :send_message, fn _, message ->
@@ -521,39 +428,7 @@ defmodule Hermes.ClientTest do
   end
 
   describe "server information" do
-    setup do
-      expect(Hermes.MockTransport, :send_message, 2, fn _, _message -> :ok end)
-
-      client =
-        start_supervised!(
-          {Hermes.Client,
-           transport: [layer: Hermes.MockTransport, name: Hermes.MockTransportImpl],
-           client_info: %{"name" => "TestClient", "version" => "1.0.0"}},
-          restart: :temporary
-        )
-
-      allow(Hermes.MockTransport, self(), client)
-
-      initialize_client(client)
-
-      assert request_id = get_request_id(client, "initialize")
-
-      init_response = %{
-        "id" => request_id,
-        "jsonrpc" => "2.0",
-        "result" => %{
-          "capabilities" => %{"resources" => %{"subscribe" => true}, "tools" => %{}, "completion" => %{}},
-          "serverInfo" => %{"name" => "TestServer", "version" => "1.0.0"},
-          "protocolVersion" => "2024-11-05"
-        }
-      }
-
-      send_response(client, init_response)
-
-      Process.sleep(500)
-
-      %{client: client}
-    end
+    setup :setup_initialized_client
 
     test "get_server_capabilities returns server capabilities", %{client: client} do
       capabilities = Hermes.Client.get_server_capabilities(client)
@@ -574,39 +449,7 @@ defmodule Hermes.ClientTest do
   end
 
   describe "progress tracking" do
-    setup do
-      expect(Hermes.MockTransport, :send_message, 2, fn _, _message -> :ok end)
-
-      client =
-        start_supervised!(
-          {Hermes.Client,
-           transport: [layer: Hermes.MockTransport, name: Hermes.MockTransportImpl],
-           client_info: %{"name" => "TestClient", "version" => "1.0.0"}},
-          restart: :temporary
-        )
-
-      allow(Hermes.MockTransport, self(), client)
-
-      initialize_client(client)
-
-      assert request_id = get_request_id(client, "initialize")
-
-      init_response = %{
-        "id" => request_id,
-        "jsonrpc" => "2.0",
-        "result" => %{
-          "capabilities" => %{"resources" => %{}, "tools" => %{}, "prompts" => %{}, "completion" => %{"complete" => true}},
-          "serverInfo" => %{"name" => "TestServer", "version" => "1.0.0"},
-          "protocolVersion" => "2024-11-05"
-        }
-      }
-
-      send_response(client, init_response)
-
-      Process.sleep(50)
-
-      %{client: client}
-    end
+    setup :setup_initialized_client
 
     test "registers and calls progress callback when notification is received", %{client: client} do
       # Variables for progress tracking
@@ -694,40 +537,7 @@ defmodule Hermes.ClientTest do
   end
 
   describe "logging" do
-    setup do
-      expect(Hermes.MockTransport, :send_message, 2, fn _, _message -> :ok end)
-
-      client =
-        start_supervised!(
-          {Hermes.Client,
-           transport: [layer: Hermes.MockTransport, name: Hermes.MockTransportImpl],
-           client_info: %{"name" => "TestClient", "version" => "1.0.0"}},
-          restart: :temporary
-        )
-
-      allow(Hermes.MockTransport, self(), client)
-
-      # Initialize the client
-      initialize_client(client)
-
-      assert request_id = get_request_id(client, "initialize")
-
-      init_response = %{
-        "id" => request_id,
-        "jsonrpc" => "2.0",
-        "result" => %{
-          "capabilities" => %{"resources" => %{}, "tools" => %{}, "logging" => %{}, "completion" => %{"complete" => true}},
-          "serverInfo" => %{"name" => "TestServer", "version" => "1.0.0"},
-          "protocolVersion" => "2024-11-05"
-        }
-      }
-
-      send_response(client, init_response)
-
-      Process.sleep(50)
-
-      %{client: client}
-    end
+    setup :setup_initialized_client
 
     test "set_log_level sends the correct request", %{client: client} do
       expect(Hermes.MockTransport, :send_message, fn _, message ->
@@ -768,20 +578,11 @@ defmodule Hermes.ClientTest do
 
       Process.sleep(50)
 
-      assert request_id = get_request_id(client, "completion/complete")
+      request_id = get_request_id(client, "completion/complete")
+      assert request_id
 
-      response = %{
-        "id" => request_id,
-        "jsonrpc" => "2.0",
-        "result" => %{
-          "completion" => %{
-            "values" => ["python", "pytorch", "pyside"],
-            "total" => 3,
-            "hasMore" => false
-          }
-        }
-      }
-
+      values = ["python", "pytorch", "pyside"]
+      response = completion_complete_response(request_id, values, 3, false)
       send_response(client, response)
 
       assert {:ok, response} = Task.await(task)
@@ -789,7 +590,7 @@ defmodule Hermes.ClientTest do
 
       completion = Response.unwrap(response)["completion"]
       assert is_map(completion)
-      assert completion["values"] == ["python", "pytorch", "pyside"]
+      assert completion["values"] == values
       assert completion["total"] == 3
       assert completion["hasMore"] == false
     end
@@ -812,26 +613,17 @@ defmodule Hermes.ClientTest do
 
       Process.sleep(50)
 
-      assert request_id = get_request_id(client, "completion/complete")
+      request_id = get_request_id(client, "completion/complete")
+      assert request_id
 
-      response = %{
-        "id" => request_id,
-        "jsonrpc" => "2.0",
-        "result" => %{
-          "completion" => %{
-            "values" => ["utf-8", "utf-16"],
-            "total" => 2,
-            "hasMore" => false
-          }
-        }
-      }
-
+      values = ["utf-8", "utf-16"]
+      response = completion_complete_response(request_id, values, 2, false)
       send_response(client, response)
 
       assert {:ok, response} = Task.await(task)
 
       completion = Response.unwrap(response)["completion"]
-      assert completion["values"] == ["utf-8", "utf-16"]
+      assert completion["values"] == values
       assert completion["total"] == 2
       assert completion["hasMore"] == false
     end
@@ -901,17 +693,8 @@ defmodule Hermes.ClientTest do
 
       initialize_client(client)
 
-      assert request_id = get_request_id(client, "initialize")
-
-      init_response = %{
-        "id" => request_id,
-        "jsonrpc" => "2.0",
-        "result" => %{
-          "capabilities" => %{"completion" => %{}},
-          "serverInfo" => %{"name" => "TestServer", "version" => "1.0.0"},
-          "protocolVersion" => "2024-11-05"
-        }
-      }
+      request_id = get_request_id(client, "initialize")
+      assert request_id
 
       init_response = init_response(request_id, %{"completion" => %{}})
       send_response(client, init_response)
@@ -921,39 +704,7 @@ defmodule Hermes.ClientTest do
   end
 
   describe "cancellation" do
-    setup do
-      expect(Hermes.MockTransport, :send_message, 2, fn _, _message -> :ok end)
-
-      client =
-        start_supervised!(
-          {Hermes.Client,
-           transport: [layer: Hermes.MockTransport, name: Hermes.MockTransportImpl],
-           client_info: %{"name" => "TestClient", "version" => "1.0.0"}},
-          restart: :temporary
-        )
-
-      allow(Hermes.MockTransport, self(), client)
-
-      initialize_client(client)
-
-      assert request_id = get_request_id(client, "initialize")
-
-      init_response = %{
-        "id" => request_id,
-        "jsonrpc" => "2.0",
-        "result" => %{
-          "capabilities" => %{"resources" => %{}, "tools" => %{}, "completion" => %{}},
-          "serverInfo" => %{"name" => "TestServer", "version" => "1.0.0"},
-          "protocolVersion" => "2024-11-05"
-        }
-      }
-
-      send_response(client, init_response)
-
-      Process.sleep(50)
-
-      %{client: client}
-    end
+    setup :setup_initialized_client
 
     test "handles cancelled notification from server", %{client: client} do
       expect(Hermes.MockTransport, :send_message, fn _, message ->


### PR DESCRIPTION
## Problem

The MCP specification includes a "roots" feature that allows servers to request
filesystem boundaries from clients, but this functionality was not implemented in the
Hermes MCP client library. This feature is necessary for servers to determine where
they can safely operate in the filesystem.

## Solution

- Implemented the roots client capability with optimized data structures (hash map
instead of list)
- Added server-initiated request handling for "roots/list" method
- Implemented automatic notification of root changes through the
"notifications/roots/list_changed" notification
- Added telemetry events for roots operations with appropriate logging
- Fixed legacy error handling to properly log and emit telemetry events

## Rationale

- Used a map data structure with URI keys for O(1) lookup performance
- Implemented Task.start for non-blocking notification delivery
- Added extensive telemetry instrumentation for observability
- Properly handled error cases in compliance with the MCP protocol
- Used automatic roots/list_changed notifications to simplify client usage
