### PR TITLE
feat: enable log disabling

### DIFF
--- a/lib/hermes/client.ex
+++ b/lib/hermes/client.ex
@@ -652,7 +652,7 @@ defmodule Hermes.Client do
     # Set up logging context
     client_name = get_in(opts, [:client_info, "name"])
 
-    Logging.context(
+    Logger.metadata(
       mcp_client: opts.name,
       mcp_client_name: client_name,
       mcp_transport: opts.transport

--- a/lib/hermes/logging.ex
+++ b/lib/hermes/logging.ex
@@ -86,26 +86,15 @@ defmodule Hermes.Logging do
     end
   end
 
-  @doc """
-  Set context for all subsequent logs in the current process.
-  """
-  def context(metadata) when is_list(metadata) do
-    Logger.metadata(metadata)
-  end
-
-  @doc """
-  Add context to existing metadata for all subsequent logs.
-  """
-  def add_context(metadata) when is_list(metadata) do
-    Logger.metadata(Keyword.merge(Logger.metadata(), metadata))
-  end
-
   # Private helpers
 
-  # Route log messages to the appropriate Logger function based on level
   defp log(level, message, metadata) when is_atom(level) do
-    log_by_level(level, message, metadata)
+    if should_log?() do
+      log_by_level(level, message, metadata)
+    end
   end
+
+  defp should_log?, do: Application.get_env(:hermes_mcp, :log, true)
 
   # Map MCP log levels to Elixir logger levels
   defp log_by_level(:debug, message, metadata), do: Logger.debug(message, metadata)

--- a/lib/hermes/transport/sse.ex
+++ b/lib/hermes/transport/sse.ex
@@ -140,7 +140,7 @@ defmodule Hermes.Transport.SSE do
 
     task =
       Task.async(fn ->
-        Logging.context(parent_metadata)
+        Logger.metadata(parent_metadata)
 
         stream =
           SSE.connect(state.sse_url, state.headers,


### PR DESCRIPTION
## Problem

Issue #75 requests the ability to suppress Hermes client logging. Currently, transport
layers (STDIO, SSE, WebSocket) emit debug logs for every message sent/received,
creating noise in production environments. Users cannot disable these internal logs
without changing their global Logger configuration, which affects their entire
application.

## Solution

Added a :log configuration option to suppress all Hermes internal logging. When set to
false, the Hermes.Logging module skips all log calls, preventing transport events and
MCP message logs from being emitted.

```elixir
import Config

# Disable all Hermes internal logs
config :hermes, log: false
```

## Rationale

Follows the established pattern used by other Elixir libraries like Ecto (log: false)
and Oban (log: false). This approach provides a simple, library-specific configuration
that doesn't interfere with application-wide logging settings, allowing users to
suppress verbose transport logs while maintaining their desired Logger levels for other
 parts of their application.
