### PR TITLE
feat: allow json schema fields on tools/prompts definition

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -5,7 +5,9 @@ locals = [
   assert_notification: 2,
   component: 1,
   component: 2,
-  schema: 1
+  schema: 1,
+  field: 2,
+  field: 3
 ]
 
 test = [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        elixir: [1.18.3]
+        elixir: [1.19.0-rc.0]
         otp: [27.3]
 
     steps:
@@ -72,7 +72,7 @@ jobs:
 
     strategy:
       matrix:
-        elixir: [1.18.3]
+        elixir: [1.19.0-rc.0]
         otp: [27.3]
 
     steps:
@@ -140,7 +140,7 @@ jobs:
 
     strategy:
       matrix:
-        elixir: [1.18.3]
+        elixir: [1.19.0-rc.0]
         otp: [27.3]
 
     steps:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
         with:
-          elixir-version: '1.18.3'
+          elixir-version: '1.19.0-rc.0'
           otp-version: '27.3'
       
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
         with:
-          elixir-version: '1.18.3'
+          elixir-version: '1.19.0-rc.0'
           otp-version: '27.3'
       
       - name: Install dependencies

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,3 +140,6 @@ mix docs
 - **Testing**: Descriptive test blocks
 - **Constants**: Define defaults as module attributes (@default_*)
 - **Module Structure**: Follow pattern: moduledoc, types, constants, public API, GenServer callbacks, private helpers
+
+### Testing Guidelines
+- Always implement test helper modules in @test/support/ context, analyzing if there aren't any existing ones that could be used

--- a/lib/hermes/server/component.ex
+++ b/lib/hermes/server/component.ex
@@ -141,7 +141,7 @@ defmodule Hermes.Server.Component do
     quote do
       @behaviour unquote(behaviour_module)
 
-      import Hermes.Server.Component, only: [schema: 1]
+      import Hermes.Server.Component, only: [schema: 1, field: 3, field: 2]
 
       @doc false
       def __mcp_component_type__, do: unquote(type)
@@ -154,7 +154,7 @@ defmodule Hermes.Server.Component do
         def input_schema do
           alias Hermes.Server.Component.Schema
 
-          Schema.to_json_schema(get_schema(:mcp_schema))
+          Schema.to_json_schema(__mcp_raw_schema__())
         end
       end
 
@@ -197,12 +197,98 @@ defmodule Hermes.Server.Component do
           }
         }
       end
+
+      # With field metadata for JSON Schema (no braces needed!)
+      schema do
+        field(:email, {:required, :string}, format: "email", description: "User's email address")
+        field(:age, :integer, description: "Age in years")
+        field :address, description: "User's address" do
+          field(:street, {:required, :string})
+          field(:city, :string)
+          field(:country, :string, description: "ISO 3166-1 alpha-2 code")
+        end
+      end
   """
   defmacro schema(do: schema_def) do
+    wrapped_schema =
+      case schema_def do
+        {:%{}, _, _} = map_ast ->
+          map_ast
+
+        {:__block__, _, field_calls} ->
+          {:%{}, [], field_calls}
+
+        single_field ->
+          {:%{}, [], [single_field]}
+      end
+
     quote do
       import Peri
 
-      defschema :mcp_schema, unquote(schema_def)
+      alias Hermes.Server.Component
+
+      @doc false
+      def __mcp_raw_schema__, do: unquote(wrapped_schema)
+
+      defschema :mcp_schema, Component.__clean_schema_for_peri__(unquote(wrapped_schema))
+    end
+  end
+
+  @doc """
+  Defines a field with metadata for JSON Schema generation.
+
+  Supports both simple fields and nested objects with their own fields.
+
+  ## Examples
+
+      # Simple field
+      field :email, {:required, :string}, format: "email", description: "User's email address"
+      field :age, :integer, description: "Age in years"
+      
+      # Nested field
+      field :user do
+        field :name, {:required, :string}
+        field :email, :string, format: "email"
+      end
+
+      # Nested field with metadata
+      field :profile, description: "User profile information" do
+        field :bio, :string, description: "Short biography"
+        field :avatar_url, :string, format: "uri"
+      end
+  """
+  defmacro field(name, type \\ nil, opts \\ [])
+
+  defmacro field(name, opts, do: block) when is_list(opts) and opts != [] do
+    build_nested_field(name, opts, block)
+  end
+
+  defmacro field(name, nil, do: block) do
+    build_nested_field(name, [], block)
+  end
+
+  defmacro field(name, [do: block], []) do
+    build_nested_field(name, [], block)
+  end
+
+  defmacro field(name, type, opts) when not is_nil(type) and is_list(opts) do
+    quote do
+      {unquote(name), {:mcp_field, unquote(type), unquote(opts)}}
+    end
+  end
+
+  defp build_nested_field(name, opts, block) do
+    nested_content =
+      case block do
+        {:__block__, _, expressions} ->
+          {:%{}, [], expressions}
+
+        single_expr ->
+          {:%{}, [], [single_expr]}
+      end
+
+    quote do
+      {unquote(name), {:mcp_field, unquote(nested_content), unquote(opts)}}
     end
   end
 
@@ -287,4 +373,15 @@ defmodule Hermes.Server.Component do
   def component?(module) when is_atom(module) do
     not is_nil(get_type(module))
   end
+
+  @doc false
+  def __clean_schema_for_peri__(schema) when is_map(schema) do
+    Map.new(schema, fn
+      {key, {:mcp_field, type, _opts}} -> {key, __clean_schema_for_peri__(type)}
+      {key, nested} when is_map(nested) -> {key, __clean_schema_for_peri__(nested)}
+      {key, value} -> {key, value}
+    end)
+  end
+
+  def __clean_schema_for_peri__(schema), do: schema
 end

--- a/lib/hermes/server/component.ex
+++ b/lib/hermes/server/component.ex
@@ -163,7 +163,7 @@ defmodule Hermes.Server.Component do
         def arguments do
           alias Hermes.Server.Component.Schema
 
-          Schema.to_prompt_arguments(get_schema(:mcp_schema))
+          Schema.to_prompt_arguments(__mcp_raw_schema__())
         end
       end
 

--- a/test/hermes/server/component_field_macro_test.exs
+++ b/test/hermes/server/component_field_macro_test.exs
@@ -1,0 +1,219 @@
+defmodule Hermes.Server.ComponentFieldMacroTest do
+  use ExUnit.Case, async: true
+
+  alias TestTools.DeeplyNestedTool
+  alias TestTools.LegacyTool
+  alias TestTools.NestedFieldTool
+  alias TestTools.SingleNestedFieldTool
+
+  describe "field macro with nested do blocks" do
+    test "generates correct JSON Schema with nested fields" do
+      json_schema = NestedFieldTool.input_schema()
+
+      assert json_schema == %{
+               "type" => "object",
+               "properties" => %{
+                 "name" => %{
+                   "type" => "string",
+                   "description" => "Full name"
+                 },
+                 "address" => %{
+                   "type" => "object",
+                   "description" => "Mailing address",
+                   "properties" => %{
+                     "street" => %{"type" => "string"},
+                     "city" => %{"type" => "string"},
+                     "state" => %{"type" => "string"},
+                     "zip" => %{
+                       "type" => "string",
+                       "format" => "postal-code"
+                     }
+                   },
+                   "required" => ["street", "city"]
+                 },
+                 "contact" => %{
+                   "type" => "object",
+                   "properties" => %{
+                     "email" => %{
+                       "type" => "string",
+                       "format" => "email",
+                       "description" => "Contact email"
+                     },
+                     "phone" => %{
+                       "type" => "string",
+                       "format" => "phone"
+                     }
+                   }
+                 }
+               },
+               "required" => ["name"]
+             }
+
+      # Verify Peri validation still works
+      assert {:ok, _} =
+               NestedFieldTool.mcp_schema(%{
+                 name: "John Doe",
+                 address: %{
+                   street: "123 Main St",
+                   city: "New York",
+                   state: "NY",
+                   zip: "10001"
+                 },
+                 contact: %{
+                   email: "john@example.com",
+                   phone: "+1-555-0123"
+                 }
+               })
+
+      # Missing required fields should fail
+      assert {:error, _} =
+               NestedFieldTool.mcp_schema(%{
+                 name: "John Doe",
+                 address: %{
+                   city: "New York"
+                   # Missing required street
+                 }
+               })
+    end
+
+    test "supports single field in nested block" do
+      json_schema = SingleNestedFieldTool.input_schema()
+
+      assert json_schema == %{
+               "type" => "object",
+               "properties" => %{
+                 "user" => %{
+                   "type" => "object",
+                   "description" => "User information",
+                   "properties" => %{
+                     "id" => %{
+                       "type" => "string",
+                       "format" => "uuid"
+                     }
+                   },
+                   "required" => ["id"]
+                 }
+               }
+             }
+    end
+
+    test "supports deeply nested fields" do
+      json_schema = DeeplyNestedTool.input_schema()
+
+      assert json_schema["properties"]["organization"]["properties"]["admin"]["properties"]["permissions"] == %{
+               "type" => "object",
+               "properties" => %{
+                 "read" => %{"type" => "boolean"},
+                 "write" => %{"type" => "boolean"},
+                 "delete" => %{"type" => "boolean"}
+               },
+               "required" => ["read", "write"]
+             }
+    end
+  end
+
+  describe "cleaner schema syntax without braces" do
+    test "allows defining schemas without explicit map braces" do
+      defmodule CleanSyntaxTool do
+        @moduledoc "Tool demonstrating clean syntax"
+
+        use Hermes.Server.Component, type: :tool
+
+        # No braces needed!
+        schema do
+          field(:title, {:required, :string}, description: "Title of the item")
+          field(:priority, {:enum, ["low", "medium", "high"]}, description: "Priority level")
+
+          field :metadata do
+            field(:created_at, :string, format: "date-time")
+            field(:tags, {:list, :string})
+          end
+        end
+
+        @impl true
+        def execute(params, frame) do
+          {:reply, %{processed: params}, frame}
+        end
+      end
+
+      json_schema = CleanSyntaxTool.input_schema()
+
+      assert json_schema["properties"]["title"]["description"] == "Title of the item"
+      assert json_schema["properties"]["priority"]["enum"] == ["low", "medium", "high"]
+      assert json_schema["properties"]["metadata"]["properties"]["created_at"]["format"] == "date-time"
+      assert json_schema["required"] == ["title"]
+    end
+  end
+
+  describe "backward compatibility with legacy schemas" do
+    test "legacy Peri schema without field macros still works" do
+      json_schema = LegacyTool.input_schema()
+
+      assert json_schema == %{
+               "type" => "object",
+               "properties" => %{
+                 "name" => %{"type" => "string"},
+                 "age" => %{"type" => "integer"},
+                 "email" => %{"type" => "string"},
+                 "tags" => %{
+                   "type" => "array",
+                   "items" => %{"type" => "string"}
+                 },
+                 "metadata" => %{
+                   "type" => "object",
+                   "properties" => %{
+                     "created_at" => %{"type" => "string"},
+                     "updated_at" => %{"type" => "string"}
+                   }
+                 }
+               },
+               "required" => ["name"]
+             }
+    end
+
+    test "legacy schema Peri validation works correctly" do
+      # Valid data
+      assert {:ok, _} =
+               LegacyTool.mcp_schema(%{
+                 name: "John Doe",
+                 age: 30,
+                 email: "john@example.com",
+                 tags: ["developer", "elixir"],
+                 metadata: %{
+                   created_at: "2024-01-01",
+                   updated_at: "2024-01-02"
+                 }
+               })
+
+      # Default value applied
+      assert {:ok, validated} =
+               LegacyTool.mcp_schema(%{
+                 name: "Jane Doe"
+               })
+
+      assert validated.age == 25
+
+      # Missing required field
+      assert {:error, _} =
+               LegacyTool.mcp_schema(%{
+                 age: 30,
+                 email: "test@example.com"
+               })
+    end
+
+    test "mixing field macros and legacy schemas in different tools" do
+      # Both styles should work independently
+      nested_schema = NestedFieldTool.input_schema()
+      legacy_schema = LegacyTool.input_schema()
+
+      # Ensure they are different structures
+      refute nested_schema == legacy_schema
+
+      # Both should have valid JSON Schema structure
+      assert nested_schema["type"] == "object"
+      assert legacy_schema["type"] == "object"
+      assert is_map(nested_schema["properties"])
+      assert is_map(legacy_schema["properties"])
+    end
+  end
+end

--- a/test/hermes/server/component_prompt_test.exs
+++ b/test/hermes/server/component_prompt_test.exs
@@ -1,0 +1,57 @@
+defmodule Hermes.Server.ComponentPromptTest do
+  use ExUnit.Case, async: true
+
+  alias TestPrompts.FieldPrompt
+  alias TestPrompts.LegacyPrompt
+  alias TestPrompts.NestedPrompt
+
+  describe "prompt with field metadata" do
+    test "generates correct arguments with descriptions" do
+      arguments = FieldPrompt.arguments()
+
+      assert length(arguments) == 3
+
+      assert %{
+               "name" => "code",
+               "description" => "The code to review",
+               "required" => true
+             } in arguments
+
+      assert %{
+               "name" => "language",
+               "description" => "Programming language",
+               "required" => true
+             } in arguments
+
+      assert %{
+               "name" => "focus_areas",
+               "description" => "Areas to focus on (optional)",
+               "required" => false
+             } in arguments
+    end
+
+    test "supports nested fields in prompts" do
+      arguments = NestedPrompt.arguments()
+
+      assert [%{"name" => "config", "description" => "Configuration options", "required" => false}] = arguments
+    end
+
+    test "backward compatibility with legacy prompt schemas" do
+      arguments = LegacyPrompt.arguments()
+
+      assert length(arguments) == 2
+
+      assert %{
+               "name" => "query",
+               "description" => "Required string parameter",
+               "required" => true
+             } in arguments
+
+      assert %{
+               "name" => "max_results",
+               "description" => "Optional integer parameter (default: 10)",
+               "required" => false
+             } in arguments
+    end
+  end
+end

--- a/test/support/test_tools.ex
+++ b/test/support/test_tools.ex
@@ -3,6 +3,8 @@ defmodule TestTools.NestedFieldTool do
 
   use Hermes.Server.Component, type: :tool
 
+  alias Hermes.Server.Response
+
   schema do
     field :name, {:required, :string}, description: "Full name"
 
@@ -21,7 +23,7 @@ defmodule TestTools.NestedFieldTool do
 
   @impl true
   def execute(_params, frame) do
-    {:reply, %{success: true}, frame}
+    {:reply, Response.text(Response.tool(), "it doesnt matter"), frame}
   end
 end
 
@@ -29,6 +31,8 @@ defmodule TestTools.SingleNestedFieldTool do
   @moduledoc "Tool with single nested field"
 
   use Hermes.Server.Component, type: :tool
+
+  alias Hermes.Server.Response
 
   schema do
     field :user, description: "User information" do
@@ -38,7 +42,7 @@ defmodule TestTools.SingleNestedFieldTool do
 
   @impl true
   def execute(_params, frame) do
-    {:reply, %{success: true}, frame}
+    {:reply, Response.text(Response.tool(), "doesnt matter"), frame}
   end
 end
 
@@ -46,6 +50,8 @@ defmodule TestTools.DeeplyNestedTool do
   @moduledoc "Tool with deeply nested fields"
 
   use Hermes.Server.Component, type: :tool
+
+  alias Hermes.Server.Response
 
   schema do
     field :organization do
@@ -65,7 +71,7 @@ defmodule TestTools.DeeplyNestedTool do
 
   @impl true
   def execute(_params, frame) do
-    {:reply, %{success: true}, frame}
+    {:reply, Response.text(Response.tool(), "doesnt matter"), frame}
   end
 end
 
@@ -73,6 +79,8 @@ defmodule TestTools.LegacyTool do
   @moduledoc "Tool using traditional Peri schema syntax without field macros"
 
   use Hermes.Server.Component, type: :tool
+
+  alias Hermes.Server.Response
 
   schema do
     %{
@@ -89,6 +97,65 @@ defmodule TestTools.LegacyTool do
 
   @impl true
   def execute(_params, frame) do
-    {:reply, %{success: true}, frame}
+    {:reply, Response.text(Response.tool(), "doesnt matter"), frame}
+  end
+end
+
+defmodule TestPrompts.FieldPrompt do
+  @moduledoc "Test prompt with field metadata"
+
+  use Hermes.Server.Component, type: :prompt
+
+  alias Hermes.Server.Response
+
+  schema do
+    field :code, {:required, :string}, description: "The code to review"
+    field :language, {:required, :string}, description: "Programming language"
+    field :focus_areas, :string, description: "Areas to focus on (optional)"
+  end
+
+  @impl true
+  def get_messages(_params, frame) do
+    {:reply, Response.user_message(Response.prompt(), "hello"), frame}
+  end
+end
+
+defmodule TestPrompts.NestedPrompt do
+  @moduledoc "Prompt with nested fields"
+
+  use Hermes.Server.Component, type: :prompt
+
+  alias Hermes.Server.Response
+
+  schema do
+    field :config, description: "Configuration options" do
+      field :model, {:required, :string}, description: "Model to use"
+      field :temperature, :float, description: "Temperature setting"
+    end
+  end
+
+  @impl true
+  def get_messages(_params, frame) do
+    {:reply, Response.user_message(Response.prompt(), "hello"), frame}
+  end
+end
+
+defmodule TestPrompts.LegacyPrompt do
+  @moduledoc "Legacy prompt without field macros"
+
+  use Hermes.Server.Component, type: :prompt
+
+  alias Hermes.Server.Response
+
+  schema do
+    %{
+      query: {:required, :string},
+      max_results: {:integer, {:default, 10}}
+    }
+  end
+
+  @impl true
+  def get_messages(_params, frame) do
+    {:reply, Response.user_message(Response.prompt(), "hello"), frame}
   end
 end

--- a/test/support/test_tools.ex
+++ b/test/support/test_tools.ex
@@ -1,0 +1,94 @@
+defmodule TestTools.NestedFieldTool do
+  @moduledoc "Tool with nested field definitions"
+
+  use Hermes.Server.Component, type: :tool
+
+  schema do
+    field :name, {:required, :string}, description: "Full name"
+
+    field :address, description: "Mailing address" do
+      field :street, {:required, :string}
+      field :city, {:required, :string}
+      field :state, :string
+      field :zip, :string, format: "postal-code"
+    end
+
+    field :contact do
+      field :email, :string, format: "email", description: "Contact email"
+      field :phone, :string, format: "phone"
+    end
+  end
+
+  @impl true
+  def execute(_params, frame) do
+    {:reply, %{success: true}, frame}
+  end
+end
+
+defmodule TestTools.SingleNestedFieldTool do
+  @moduledoc "Tool with single nested field"
+
+  use Hermes.Server.Component, type: :tool
+
+  schema do
+    field :user, description: "User information" do
+      field :id, {:required, :string}, format: "uuid"
+    end
+  end
+
+  @impl true
+  def execute(_params, frame) do
+    {:reply, %{success: true}, frame}
+  end
+end
+
+defmodule TestTools.DeeplyNestedTool do
+  @moduledoc "Tool with deeply nested fields"
+
+  use Hermes.Server.Component, type: :tool
+
+  schema do
+    field :organization do
+      field :name, {:required, :string}
+
+      field :admin, description: "Organization admin" do
+        field :name, {:required, :string}
+
+        field :permissions do
+          field :read, {:required, :boolean}
+          field :write, {:required, :boolean}
+          field :delete, :boolean
+        end
+      end
+    end
+  end
+
+  @impl true
+  def execute(_params, frame) do
+    {:reply, %{success: true}, frame}
+  end
+end
+
+defmodule TestTools.LegacyTool do
+  @moduledoc "Tool using traditional Peri schema syntax without field macros"
+
+  use Hermes.Server.Component, type: :tool
+
+  schema do
+    %{
+      name: {:required, :string},
+      age: {:integer, {:default, 25}},
+      email: :string,
+      tags: {:list, :string},
+      metadata: %{
+        created_at: :string,
+        updated_at: :string
+      }
+    }
+  end
+
+  @impl true
+  def execute(_params, frame) do
+    {:reply, %{success: true}, frame}
+  end
+end


### PR DESCRIPTION
## Problem

The MCP protocol requires JSON Schema format for tool input schemas, but Peri (our validation library) doesn't support JSON
Schema metadata like format and description fields. This limits the ability to provide rich documentation and validation hints
to MCP clients.

Closes #95

## Solution

Added a field/2 and field/3 macro that wraps Peri types with metadata using :mcp_field tuples. The implementation:
- Stores raw schema with metadata in __mcp_raw_schema__() for JSON Schema generation
- Strips metadata for Peri validation using __clean_schema_for_peri__/1
- Supports nested fields with clean syntax (no explicit map braces needed)
- Works for both tools and prompts

## Rationale

Maintained an in-house solution rather than modifying Peri to keep the implementation simple and avoid upstream dependencies.
The dual schema approach (raw with metadata, cleaned for validation) ensures backward compatibility while enabling richer MCP
protocol support. The macro design allows gradual adoption - existing Peri schemas continue to work unchanged.
