### PR TITLE
fix: allow registering a name for the client supervisor

### DIFF
--- a/lib/hermes/client/supervisor.ex
+++ b/lib/hermes/client/supervisor.ex
@@ -76,7 +76,13 @@ defmodule Hermes.Client.Supervisor do
   """
   @spec start_link(module(), keyword()) :: Supervisor.on_start()
   def start_link(client_module, opts) do
-    Supervisor.start_link(__MODULE__, Keyword.put(opts, :client_module, client_module))
+    opts = Keyword.put(opts, :client_module, client_module)
+
+    if name = Keyword.get(opts, :name) do
+      Supervisor.start_link(__MODULE__, opts, name: name)
+    else
+      Supervisor.start_link(__MODULE__, opts)
+    end
   end
 
   @impl true
@@ -88,7 +94,7 @@ defmodule Hermes.Client.Supervisor do
     capabilities = Keyword.fetch!(opts, :capabilities)
     protocol_version = Keyword.fetch!(opts, :protocol_version)
 
-    client_name = opts[:name] || client_module
+    client_name = opts[:client_name] || client_module
     transport_name = derive_transport_name(opts[:transport_name], client_name)
 
     {layer, transport_opts} = parse_transport_config(transport)


### PR DESCRIPTION
## Problem

it was impossible to register a name for the `Hermes.Client.Supervisor` process, only allowing to registering a name for its children, this blocks for example if one would like to clusterize, it was only possible to clusterize the children, which isnt so much practical

## Solution

allow registering a name for the supervisor process and rename the `:name` option to `:client_name`, so we now have:

- `:name`, for the supervisor name (optional, default no name)
- `:client_name`, for the `Hermes.Client.Base` process name (optional, default to the module passed to start_link/2)
- `:transport_name`, for the transport to be used by the client process name (optional, default to derive from the client)

## Rationale

N/A
