### PR TITLE
feat: tools annotations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ mix docs
   - Reduces test boilerplate by ~90% while maintaining flexibility
   - Uses MockTransport (test double) instead of real transports like STDIO/HTTP
   - No mocking library needed - MockTransport is already a test implementation
-- **Message Builders**: Use MCPTest builders for consistent message construction
+- **Message Builders**: Use Hermes.MCP.Builders builders for consistent message construction
   - `init_request/1`, `ping_request/0`, `tools_list_request/1`, etc.
   - `build_request/2`, `build_response/2`, `build_notification/2` for custom messages
 - **Setup Functions**: Use composable setup functions for test contexts
@@ -109,25 +109,6 @@ mix docs
 - **MCP Assertions**: Use domain-specific assertions for clear error messages
   - `assert_mcp_response/2`, `assert_mcp_error/3`, `assert_mcp_notification/2`
   - `assert_success/2`, `assert_resources/2`, `assert_tools/2`
-- **Usage Example**:
-  ```elixir
-  defmodule MyMCPTest do
-    use MCPTest.Case
-    
-    @tag server: true
-    test "handles initialization", %{server: server} do
-      request = init_request()
-      {:ok, encoded} = Message.encode_request(request, 1)
-      {:ok, response} = GenServer.call(server, {:message, encoded})
-      {:ok, [decoded]} = Message.decode(response)
-      
-      assert_mcp_response(decoded, %{
-        "protocolVersion" => "2025-03-26",
-        "serverInfo" => %{"name" => "Test Server", "version" => "1.0.0"}
-      })
-    end
-  end
-  ```
 
 ## Code Style Guidelines
 - **Code Comments**: Only add code comments if strictly necessary, avoid it generally

--- a/lib/hermes/client/state.ex
+++ b/lib/hermes/client/state.ex
@@ -167,14 +167,16 @@ defmodule Hermes.Client.State do
   Helper function to add progress token to params if provided.
   """
   @spec add_progress_token_to_params(map(), keyword() | nil) :: map()
-  def add_progress_token_to_params(params, progress_opts) do
-    with {:ok, opts} when not is_nil(opts) <- {:ok, progress_opts},
-         {:ok, token} when not is_nil(token) and (is_binary(token) or is_integer(token)) <-
-           {:ok, Keyword.get(opts, :token)} do
-      meta = %{"progressToken" => token}
-      Map.put(params, "_meta", meta)
+  def add_progress_token_to_params(params, nil), do: params
+  def add_progress_token_to_params(params, []), do: params
+
+  def add_progress_token_to_params(params, progress_opts) when is_list(progress_opts) do
+    token = Keyword.get(progress_opts, :token)
+
+    if is_binary(token) or is_integer(token) do
+      Map.put(params, "_meta", %{"progressToken" => token})
     else
-      _ -> params
+      params
     end
   end
 

--- a/lib/hermes/server/component.ex
+++ b/lib/hermes/server/component.ex
@@ -137,6 +137,7 @@ defmodule Hermes.Server.Component do
 
     uri = Keyword.get(opts, :uri)
     mime_type = Keyword.get(opts, :mime_type, "text/plain")
+    annotations = Keyword.get(opts, :annotations)
 
     quote do
       @behaviour unquote(behaviour_module)
@@ -155,6 +156,11 @@ defmodule Hermes.Server.Component do
           alias Hermes.Server.Component.Schema
 
           Schema.to_json_schema(__mcp_raw_schema__())
+        end
+
+        if unquote(annotations) != nil do
+          @impl true
+          def annotations, do: unquote(annotations)
         end
       end
 

--- a/lib/hermes/server/component/tool.ex
+++ b/lib/hermes/server/component/tool.ex
@@ -134,9 +134,10 @@ defmodule Hermes.Server.Component.Tool do
   ## Parameters
     * `tool_module` - The tool module
     * `name` - The tool name (optional, defaults to deriving from module name)
+    * `protocol_version` - The protocol version (optional, defaults to "2024-11-05")
   """
-  @spec to_protocol(module(), String.t() | nil) :: map()
-  def to_protocol(tool_module, name \\ nil) do
+  @spec to_protocol(module(), String.t() | nil, String.t()) :: map()
+  def to_protocol(tool_module, name \\ nil, protocol_version \\ "2024-11-05") do
     name = name || derive_tool_name(tool_module)
 
     base = %{
@@ -145,7 +146,9 @@ defmodule Hermes.Server.Component.Tool do
       "inputSchema" => tool_module.input_schema()
     }
 
-    if Code.ensure_loaded?(tool_module) and function_exported?(tool_module, :annotations, 0) do
+    # Only include annotations if protocol version supports it
+    if Hermes.Protocol.supports_feature?(protocol_version, :tool_annotations) and
+         Code.ensure_loaded?(tool_module) and function_exported?(tool_module, :annotations, 0) do
       Map.put(base, "annotations", tool_module.annotations())
     else
       base

--- a/lib/hermes/server/component/tool.ex
+++ b/lib/hermes/server/component/tool.ex
@@ -56,12 +56,14 @@ defmodule Hermes.Server.Component.Tool do
   """
 
   alias Hermes.MCP.Error
+  alias Hermes.Server.Component
   alias Hermes.Server.Frame
   alias Hermes.Server.Response
 
   @type params :: map()
   @type result :: term()
   @type schema :: map()
+  @type annotations :: map() | nil
 
   @doc """
   Returns the JSON Schema for the tool's input parameters.
@@ -70,6 +72,25 @@ defmodule Hermes.Server.Component.Tool do
   The schema should follow the JSON Schema specification.
   """
   @callback input_schema() :: schema()
+
+  @doc """
+  Returns optional annotations for the tool.
+
+  Annotations provide additional metadata about the tool that may be used
+  by clients for enhanced functionality. This is an optional callback.
+
+  ## Examples
+
+      def annotations do
+        %{
+          "confidence" => 0.95,
+          "category" => "text-processing",
+          "tags" => ["nlp", "text"]
+        }
+      end
+  """
+  @callback annotations() :: annotations()
+  @optional_callbacks annotations: 0
 
   @doc """
   Executes the tool with the given parameters.
@@ -109,14 +130,33 @@ defmodule Hermes.Server.Component.Tool do
 
   @doc """
   Converts a tool module into the MCP protocol format.
+
+  ## Parameters
+    * `tool_module` - The tool module
+    * `name` - The tool name (optional, defaults to deriving from module name)
   """
-  @spec to_protocol(module()) :: map()
-  def to_protocol(tool_module) do
-    %{
-      "name" => tool_module.name(),
-      "description" => tool_module.description(),
+  @spec to_protocol(module(), String.t() | nil) :: map()
+  def to_protocol(tool_module, name \\ nil) do
+    name = name || derive_tool_name(tool_module)
+
+    base = %{
+      "name" => name,
+      "description" => Component.get_description(tool_module),
       "inputSchema" => tool_module.input_schema()
     }
+
+    if Code.ensure_loaded?(tool_module) and function_exported?(tool_module, :annotations, 0) do
+      Map.put(base, "annotations", tool_module.annotations())
+    else
+      base
+    end
+  end
+
+  defp derive_tool_name(module) do
+    module
+    |> Module.split()
+    |> List.last()
+    |> Macro.underscore()
   end
 
   @doc """

--- a/lib/hermes/server/handlers/tools.ex
+++ b/lib/hermes/server/handlers/tools.ex
@@ -89,11 +89,17 @@ defmodule Hermes.Server.Handlers.Tools do
   end
 
   defp parse_tool_definition({name, module}) do
-    %{
+    base = %{
       "name" => name,
       "description" => Component.get_description(module),
       "inputSchema" => module.input_schema()
     }
+
+    if Code.ensure_loaded?(module) and function_exported?(module, :annotations, 0) do
+      Map.put(base, "annotations", module.annotations())
+    else
+      base
+    end
   end
 
   defp validate_params(params, module, frame) do

--- a/lib/hermes/server/handlers/tools.ex
+++ b/lib/hermes/server/handlers/tools.ex
@@ -96,7 +96,6 @@ defmodule Hermes.Server.Handlers.Tools do
       "inputSchema" => module.input_schema()
     }
 
-    # Only include annotations if protocol version supports it
     if Hermes.Protocol.supports_feature?(protocol_version, :tool_annotations) and
          Code.ensure_loaded?(module) and function_exported?(module, :annotations, 0) do
       Map.put(base, "annotations", module.annotations())

--- a/lib/hermes/server/handlers/tools.ex
+++ b/lib/hermes/server/handlers/tools.ex
@@ -47,7 +47,8 @@ defmodule Hermes.Server.Handlers.Tools do
           {:reply, map(), Frame.t()} | {:error, Error.t(), Frame.t()}
   def handle_list(frame, server_module) do
     tools = server_module.__components__(:tool)
-    response = %{"tools" => Enum.map(tools, &parse_tool_definition/1)}
+    protocol_version = Frame.get_protocol_version(frame) || "2024-11-05"
+    response = %{"tools" => Enum.map(tools, &parse_tool_definition(&1, protocol_version))}
 
     {:reply, response, frame}
   end
@@ -88,14 +89,16 @@ defmodule Hermes.Server.Handlers.Tools do
     end)
   end
 
-  defp parse_tool_definition({name, module}) do
+  defp parse_tool_definition({name, module}, protocol_version) do
     base = %{
       "name" => name,
       "description" => Component.get_description(module),
       "inputSchema" => module.input_schema()
     }
 
-    if Code.ensure_loaded?(module) and function_exported?(module, :annotations, 0) do
+    # Only include annotations if protocol version supports it
+    if Hermes.Protocol.supports_feature?(protocol_version, :tool_annotations) and
+         Code.ensure_loaded?(module) and function_exported?(module, :annotations, 0) do
       Map.put(base, "annotations", module.annotations())
     else
       base

--- a/test/hermes/client/base_test.exs
+++ b/test/hermes/client/base_test.exs
@@ -481,7 +481,7 @@ defmodule Hermes.Client.BaseTest do
       expect(Hermes.MockTransport, :send_message, fn _, message ->
         decoded = JSON.decode!(message)
         assert decoded["method"] == "resources/list"
-        assert get_in(decoded, ["params", "_meta", "progressToken"]) == progress_token
+        assert decoded["params"] == %{"_meta" => %{"progressToken" => progress_token}}
         :ok
       end)
 

--- a/test/hermes/server/base_test.exs
+++ b/test/hermes/server/base_test.exs
@@ -186,5 +186,45 @@ defmodule Hermes.Server.BaseTest do
 
       assert Enum.all?(responses, &(&1["error"]["code"] == -32_600))
     end
+
+    test "returns error when protocol version doesn't support batching", %{server: server, session_id: session_id} do
+      # First initialize a session with the current protocol version
+      init_msg = init_request("2025-03-26", %{"name" => "TestClient", "version" => "1.0.0"})
+      assert {:ok, response} = GenServer.call(server, {:request, init_msg, session_id, %{}})
+      assert {:ok, response_data} = response
+      assert {:ok, [decoded]} = Message.decode(response_data)
+      assert decoded["result"]["protocolVersion"] == "2025-03-26"
+
+      # Now manually create a session with old protocol version
+      session_name = {:via, Registry, {Hermes.Server.Registry, {:session, StubServer, "old_protocol_session"}}}
+
+      {:ok, session} =
+        Hermes.Server.Session.start_link(
+          session_id: "old_protocol_session",
+          name: session_name
+        )
+
+      # Update the session with old protocol version
+      Agent.update(session, fn state ->
+        %{
+          state
+          | protocol_version: "2024-11-05",
+            client_info: %{"name" => "TestClient", "version" => "1.0.0"},
+            client_capabilities: %{},
+            initialized: true
+        }
+      end)
+
+      # Try to send a batch request with the old protocol session
+      batch = [
+        build_request("ping", %{}, "ping_id")
+      ]
+
+      assert {:error, error} = GenServer.call(server, {:batch_request, batch, "old_protocol_session", %{}})
+      assert error.reason == :invalid_request
+      assert error.data.feature == "batch operations"
+      assert error.data.protocol_version == "2024-11-05"
+      assert error.data.required_version == "2025-03-26"
+    end
   end
 end

--- a/test/hermes/server/component/tool_annotations_test.exs
+++ b/test/hermes/server/component/tool_annotations_test.exs
@@ -1,0 +1,204 @@
+defmodule Hermes.Server.Component.ToolAnnotationsTest do
+  use Hermes.MCP.Case, async: true
+
+  alias Hermes.MCP.Message
+  alias Hermes.Server.Component
+  alias Hermes.Server.Component.Tool
+
+  defmodule ToolWithAnnotations do
+    @moduledoc "A tool with annotations"
+
+    use Component,
+      type: :tool,
+      annotations: %{
+        "confidence" => 0.95,
+        "category" => "text-processing",
+        "tags" => ["nlp", "text", "analysis"]
+      }
+
+    alias Hermes.Server.Response
+
+    schema do
+      field :text, {:required, :string}, description: "Text to process"
+    end
+
+    @impl true
+    def execute(%{text: text}, frame) do
+      {:reply, Response.text(Response.tool(), "Processed: #{text}"), frame}
+    end
+  end
+
+  defmodule ToolWithoutAnnotations do
+    @moduledoc "A tool without annotations"
+
+    use Component, type: :tool
+
+    alias Hermes.Server.Response
+
+    schema do
+      field :input, {:required, :string}, description: "Input value"
+    end
+
+    @impl true
+    def execute(%{input: input}, frame) do
+      {:reply, Response.text(Response.tool(), "Result: #{input}"), frame}
+    end
+  end
+
+  defmodule ToolWithCustomAnnotations do
+    @moduledoc "A tool with custom annotations implementation"
+
+    use Component, type: :tool
+
+    alias Hermes.Server.Response
+
+    schema do
+      field :data, {:required, :string}, description: "Data to process"
+    end
+
+    @impl true
+    def execute(%{data: data}, frame) do
+      {:reply, Response.text(Response.tool(), "Custom: #{data}"), frame}
+    end
+
+    @impl true
+    def annotations do
+      %{
+        "version" => "2.0",
+        "experimental" => true,
+        "capabilities" => %{
+          "streaming" => false,
+          "batch" => true
+        }
+      }
+    end
+  end
+
+  describe "tool annotations" do
+    test "tool with annotations in use macro" do
+      protocol = Tool.to_protocol(ToolWithAnnotations)
+
+      assert protocol["name"] == "tool_with_annotations"
+      assert protocol["description"] == "A tool with annotations"
+      assert protocol["inputSchema"]["type"] == "object"
+
+      assert protocol["annotations"] == %{
+               "confidence" => 0.95,
+               "category" => "text-processing",
+               "tags" => ["nlp", "text", "analysis"]
+             }
+    end
+
+    test "tool without annotations" do
+      protocol = Tool.to_protocol(ToolWithoutAnnotations)
+
+      assert protocol["name"] == "tool_without_annotations"
+      assert protocol["description"] == "A tool without annotations"
+      assert protocol["inputSchema"]["type"] == "object"
+      refute Map.has_key?(protocol, "annotations")
+    end
+
+    test "tool with custom annotations implementation" do
+      protocol = Tool.to_protocol(ToolWithCustomAnnotations)
+
+      assert protocol["name"] == "tool_with_custom_annotations"
+      assert protocol["description"] == "A tool with custom annotations implementation"
+      assert protocol["inputSchema"]["type"] == "object"
+
+      assert protocol["annotations"] == %{
+               "version" => "2.0",
+               "experimental" => true,
+               "capabilities" => %{
+                 "streaming" => false,
+                 "batch" => true
+               }
+             }
+    end
+
+    test "annotations callback is optional" do
+      # Verify that ToolWithAnnotations implements annotations
+      assert function_exported?(ToolWithAnnotations, :annotations, 0)
+
+      # Verify that ToolWithoutAnnotations does not implement annotations
+      refute function_exported?(ToolWithoutAnnotations, :annotations, 0)
+
+      # Verify that ToolWithCustomAnnotations implements annotations
+      assert function_exported?(ToolWithCustomAnnotations, :annotations, 0)
+    end
+  end
+
+  describe "tools/list with annotations" do
+    defmodule ServerWithAnnotatedTools do
+      @moduledoc false
+      use Hermes.Server,
+        name: "Test Server with Annotations",
+        version: "1.0.0",
+        capabilities: [:tools]
+
+      component ToolWithAnnotations
+      component ToolWithoutAnnotations
+      component ToolWithCustomAnnotations
+
+      @impl true
+      def init(_arg, frame), do: {:ok, frame}
+
+      @impl true
+      def handle_notification(_notification, frame), do: {:noreply, frame}
+    end
+
+    setup do
+      start_supervised!(Hermes.Server.Registry)
+      transport = start_supervised!(StubTransport)
+
+      # Start session supervisor
+      start_supervised!(
+        {Hermes.Server.Session.Supervisor, server: ServerWithAnnotatedTools, registry: Hermes.Server.Registry}
+      )
+
+      server_opts = [
+        module: ServerWithAnnotatedTools,
+        name: :test_server,
+        init_arg: :ok,
+        registry: Hermes.Server.Registry,
+        transport: [layer: StubTransport, name: transport]
+      ]
+
+      server = start_supervised!({Hermes.Server.Base, server_opts})
+
+      # Initialize the server
+      session_id = "test-session"
+      request = init_request("2025-03-26", %{"name" => "TestClient", "version" => "1.0.0"})
+      assert {:ok, _} = GenServer.call(server, {:request, request, session_id, %{}})
+      notification = build_notification("notifications/initialized", %{})
+      assert :ok = GenServer.cast(server, {:notification, notification, session_id, %{}})
+
+      %{server: server, session_id: session_id}
+    end
+
+    test "lists tools with and without annotations", %{server: server, session_id: session_id} do
+      request = build_request("tools/list", %{})
+      {:ok, response_string} = GenServer.call(server, {:request, request, session_id, %{}})
+
+      {:ok, [response]} = Message.decode(response_string)
+
+      assert response["result"]
+      tools = response["result"]["tools"]
+      assert length(tools) == 3
+
+      # Find each tool and verify its annotations
+      tool_with_annotations = Enum.find(tools, &(&1["name"] == "tool_with_annotations"))
+      assert tool_with_annotations["annotations"]["confidence"] == 0.95
+      assert tool_with_annotations["annotations"]["category"] == "text-processing"
+      assert tool_with_annotations["annotations"]["tags"] == ["nlp", "text", "analysis"]
+
+      tool_without_annotations = Enum.find(tools, &(&1["name"] == "tool_without_annotations"))
+      refute Map.has_key?(tool_without_annotations, "annotations")
+
+      tool_with_custom = Enum.find(tools, &(&1["name"] == "tool_with_custom_annotations"))
+      assert tool_with_custom["annotations"]["version"] == "2.0"
+      assert tool_with_custom["annotations"]["experimental"] == true
+      assert tool_with_custom["annotations"]["capabilities"]["streaming"] == false
+      assert tool_with_custom["annotations"]["capabilities"]["batch"] == true
+    end
+  end
+end

--- a/test/hermes/server/component/tool_annotations_test.exs
+++ b/test/hermes/server/component/tool_annotations_test.exs
@@ -76,7 +76,7 @@ defmodule Hermes.Server.Component.ToolAnnotationsTest do
 
   describe "tool annotations" do
     test "tool with annotations in use macro" do
-      protocol = Tool.to_protocol(ToolWithAnnotations)
+      protocol = Tool.to_protocol(ToolWithAnnotations, nil, "2025-03-26")
 
       assert protocol["name"] == "tool_with_annotations"
       assert protocol["description"] == "A tool with annotations"
@@ -90,7 +90,7 @@ defmodule Hermes.Server.Component.ToolAnnotationsTest do
     end
 
     test "tool without annotations" do
-      protocol = Tool.to_protocol(ToolWithoutAnnotations)
+      protocol = Tool.to_protocol(ToolWithoutAnnotations, nil, "2025-03-26")
 
       assert protocol["name"] == "tool_without_annotations"
       assert protocol["description"] == "A tool without annotations"
@@ -99,7 +99,7 @@ defmodule Hermes.Server.Component.ToolAnnotationsTest do
     end
 
     test "tool with custom annotations implementation" do
-      protocol = Tool.to_protocol(ToolWithCustomAnnotations)
+      protocol = Tool.to_protocol(ToolWithCustomAnnotations, nil, "2025-03-26")
 
       assert protocol["name"] == "tool_with_custom_annotations"
       assert protocol["description"] == "A tool with custom annotations implementation"


### PR DESCRIPTION
This pull request introduces enhancements to the Hermes framework, focusing on protocol version compatibility, annotations for tools, and improved handling of progress tokens. Additionally, it updates documentation and tests to reflect these changes.

### Protocol Version Compatibility Enhancements:
* [`lib/hermes/client/base.ex`](diffhunk://#diff-bfaef6ab59ba5bb96855ede4ff713c9f7923f2fc2937f45031f1f33f3e3f009aR850): Added checks to ensure batch operations are only supported for protocol versions `2025-03-26` or later. Returns an error for unsupported versions. [[1]](diffhunk://#diff-bfaef6ab59ba5bb96855ede4ff713c9f7923f2fc2937f45031f1f33f3e3f009aR850) [[2]](diffhunk://#diff-bfaef6ab59ba5bb96855ede4ff713c9f7923f2fc2937f45031f1f33f3e3f009aR860-R870)
* [`lib/hermes/server/base.ex`](diffhunk://#diff-1146a134b004c3f80ca5063ac01c480f7a3364c39d4ce152f102e24db0f18673L349-R371): Updated batch request handling to validate protocol version compatibility and return errors for unsupported versions.
* [`test/hermes/client/batch_test.exs`](diffhunk://#diff-5b5405ea2e9b5570290d456e595a110da12d7ab89fb0dd063dc920f7b73c96b6R247-R272): Added a test case to verify that batch operations return an error when the protocol version does not support batching.
* [`test/hermes/server/base_test.exs`](diffhunk://#diff-d0750e559a32f04bce63a014d6512c965e6fcc4b6a723d68680750a46dc8d009R189-R222): Added a test case to ensure the server correctly handles batch requests with unsupported protocol versions.

### Tool Annotations Support:
* [`lib/hermes/server/component/tool.ex`](diffhunk://#diff-e0a16fba4d9f213c8d4ecd4f987ee3bbfa30bf681f669046ef4e1926fd95c4a1R76-R94): Introduced optional annotations for tools, allowing additional metadata like confidence levels and categories. Updated `to_protocol/3` to include annotations if supported by the protocol version. [[1]](diffhunk://#diff-e0a16fba4d9f213c8d4ecd4f987ee3bbfa30bf681f669046ef4e1926fd95c4a1R76-R94) [[2]](diffhunk://#diff-e0a16fba4d9f213c8d4ecd4f987ee3bbfa30bf681f669046ef4e1926fd95c4a1R133-R162)
* [`lib/hermes/server/handlers/tools.ex`](diffhunk://#diff-d3567f753b885bf32c43db7cf78bd4c958601dfdea27f787802b5748de793b06L50-R51): Modified tool parsing to include annotations when supported by the protocol version. [[1]](diffhunk://#diff-d3567f753b885bf32c43db7cf78bd4c958601dfdea27f787802b5748de793b06L50-R51) [[2]](diffhunk://#diff-d3567f753b885bf32c43db7cf78bd4c958601dfdea27f787802b5748de793b06L91-R104)

### Progress Token Improvements:
* [`lib/hermes/client/state.ex`](diffhunk://#diff-a625e24af41ec83d08958576bd792f07276ddd12cb2745c43eae3627b4dd4508L170-R179): Simplified the `add_progress_token_to_params` function to improve readability and handle empty progress options directly.
* [`lib/hermes/mcp/message.ex`](diffhunk://#diff-4104d9ed3b4233021101bf919b762172bed832043927316b83d52cbf5ea6dcb3R77-L104): Enhanced the request schema to include progress tokens in `_meta` when applicable.
* [`test/hermes/client/base_test.exs`](diffhunk://#diff-01d54fe15ba0e2863ac2d6cdbdca4000baa23c0d290b458427d686e5a13668e9L484-R484): Updated tests to validate the inclusion of progress tokens in the request parameters.

### Documentation Updates:
* [`CLAUDE.md`](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L102-R102): Updated message builders to use `Hermes.MCP.Builders` and removed outdated usage examples. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L102-R102) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L112-L130)

### Codebase Refinements:
* [`lib/hermes/server/component.ex`](diffhunk://#diff-4109a93aff22606bf1a38e6cc064492b79fdab194d01432e730ff4e8aa9fcd55R140): Added support for annotations in server components, enabling enhanced functionality for tools. [[1]](diffhunk://#diff-4109a93aff22606bf1a38e6cc064492b79fdab194d01432e730ff4e8aa9fcd55R140) [[2]](diffhunk://#diff-4109a93aff22606bf1a38e6cc064492b79fdab194d01432e730ff4e8aa9fcd55R160-R164)
* [`lib/hermes/server/base.ex`](diffhunk://#diff-1146a134b004c3f80ca5063ac01c480f7a3364c39d4ce152f102e24db0f18673R61): Added missing `Hermes.Protocol` alias for consistency.