### PR TITLE
feat: missing notifications handlers

### DIFF
--- a/lib/hermes/client/base.ex
+++ b/lib/hermes/client/base.ex
@@ -1291,6 +1291,22 @@ defmodule Hermes.Client.Base do
     handle_cancelled_notification(notification, state)
   end
 
+  defp handle_notification(%{"method" => "notifications/resources/list_changed"} = notification, state) do
+    handle_resources_list_changed_notification(notification, state)
+  end
+
+  defp handle_notification(%{"method" => "notifications/resources/updated"} = notification, state) do
+    handle_resource_updated_notification(notification, state)
+  end
+
+  defp handle_notification(%{"method" => "notifications/prompts/list_changed"} = notification, state) do
+    handle_prompts_list_changed_notification(notification, state)
+  end
+
+  defp handle_notification(%{"method" => "notifications/tools/list_changed"} = notification, state) do
+    handle_tools_list_changed_notification(notification, state)
+  end
+
   defp handle_notification(_, state), do: state
 
   defp handle_cancelled_notification(%{"params" => params}, state) do
@@ -1354,6 +1370,56 @@ defmodule Hermes.Client.Base do
       end
 
     Logging.client_event("server_log", %{level: level, data: data, logger: logger}, level: elixir_level)
+  end
+
+  defp handle_resources_list_changed_notification(_notification, state) do
+    Logging.client_event("resources_list_changed", nil)
+
+    Telemetry.execute(
+      Telemetry.event_client_notification(),
+      %{system_time: System.system_time()},
+      %{method: "resources/list_changed"}
+    )
+
+    state
+  end
+
+  defp handle_resource_updated_notification(%{"params" => params}, state) do
+    uri = params["uri"]
+
+    Logging.client_event("resource_updated", %{uri: uri})
+
+    Telemetry.execute(
+      Telemetry.event_client_notification(),
+      %{system_time: System.system_time()},
+      %{method: "resources/updated", uri: uri}
+    )
+
+    state
+  end
+
+  defp handle_prompts_list_changed_notification(_notification, state) do
+    Logging.client_event("prompts_list_changed", nil)
+
+    Telemetry.execute(
+      Telemetry.event_client_notification(),
+      %{system_time: System.system_time()},
+      %{method: "prompts/list_changed"}
+    )
+
+    state
+  end
+
+  defp handle_tools_list_changed_notification(_notification, state) do
+    Logging.client_event("tools_list_changed", nil)
+
+    Telemetry.execute(
+      Telemetry.event_client_notification(),
+      %{system_time: System.system_time()},
+      %{method: "tools/list_changed"}
+    )
+
+    state
   end
 
   # Helper functions

--- a/lib/hermes/server.ex
+++ b/lib/hermes/server.ex
@@ -117,6 +117,20 @@ defmodule Hermes.Server do
       @behaviour Hermes.Server.Behaviour
 
       import Hermes.Server, only: [component: 1, component: 2]
+
+      import Hermes.Server.Base,
+        only: [
+          send_resources_list_changed: 1,
+          send_resource_updated: 2,
+          send_resource_updated: 3,
+          send_prompts_list_changed: 1,
+          send_tools_list_changed: 1,
+          send_log_message: 3,
+          send_log_message: 4,
+          send_progress: 4,
+          send_progress: 5
+        ]
+
       import Hermes.Server.Frame
 
       require Hermes.MCP.Message

--- a/lib/hermes/telemetry.ex
+++ b/lib/hermes/telemetry.ex
@@ -58,6 +58,7 @@ defmodule Hermes.Telemetry do
   def event_client_response, do: [:client, :response]
   def event_client_terminate, do: [:client, :terminate]
   def event_client_error, do: [:client, :error]
+  def event_client_notification, do: [:client, :notification]
 
   # Server events
   def event_server_init, do: [:server, :init]


### PR DESCRIPTION
This pull request introduces several enhancements to the `Hermes` module, primarily focused on improving notification handling, tracking pending requests, and extending telemetry capabilities. The changes aim to streamline server-client communication, enhance request lifecycle tracking, and provide better observability through telemetry.

### Notification Handling Enhancements
* Added new private functions in `Hermes.Client.Base` to handle various notifications (`resources/list_changed`, `resources/updated`, `prompts/list_changed`, `tools/list_changed`) and log telemetry events accordingly. (`[[1]](diffhunk://#diff-bfaef6ab59ba5bb96855ede4ff713c9f7923f2fc2937f45031f1f33f3e3f009aR1294-R1309)`, `[[2]](diffhunk://#diff-bfaef6ab59ba5bb96855ede4ff713c9f7923f2fc2937f45031f1f33f3e3f009aR1375-R1424)`)
* Introduced public functions in `Hermes.Server.Base` to send corresponding notifications to clients, such as `send_resources_list_changed`, `send_resource_updated`, `send_prompts_list_changed`, and `send_tools_list_changed`. (`[lib/hermes/server/base.exR179-R263](diffhunk://#diff-1146a134b004c3f80ca5063ac01c480f7a3364c39d4ce152f102e24db0f18673R179-R263)`)

### Request Lifecycle Tracking
* Updated `Hermes.Server.Session` to track pending requests, including their start time and method, and added functions to manage them (`track_request`, `complete_request`, `has_pending_request?`, `get_pending_requests`). (`[[1]](diffhunk://#diff-27f838a493dce5976cf8f302c1ee79c75aad6a508ed781266863b6c48e9404b2L27-R28)`, `[[2]](diffhunk://#diff-27f838a493dce5976cf8f302c1ee79c75aad6a508ed781266863b6c48e9404b2R139-R226)`)
* Modified request handling in `Hermes.Server.Base` to log and complete tracked requests upon response or cancellation. (`[[1]](diffhunk://#diff-1146a134b004c3f80ca5063ac01c480f7a3364c39d4ce152f102e24db0f18673R304-R315)`, `[[2]](diffhunk://#diff-1146a134b004c3f80ca5063ac01c480f7a3364c39d4ce152f102e24db0f18673L475-R630)`)

### Telemetry Improvements
* Added telemetry events for client notifications (`event_client_notification`) and server-side notifications (`event_server_notification`). (`[lib/hermes/telemetry.exR61](diffhunk://#diff-36ea0cbf5d67b8bff9fc1415f777a5a210c006d9d2fe9c60a3c2ad6cf1460373R61)`)