### PR TITLE
Remove last uses of hard-coded Hermes.Server.Registry

### DIFF
--- a/lib/hermes/server/base.ex
+++ b/lib/hermes/server/base.ex
@@ -726,7 +726,7 @@ defmodule Hermes.Server.Base do
   defp maybe_attach_session(session_id, context, %{sessions: sessions, registry: registry} = state) do
     session_name = registry.server_session(state.module, session_id)
 
-    case SessionSupervisor.create_session(state.module, session_id) do
+    case SessionSupervisor.create_session(registry, state.module, session_id) do
       {:ok, pid} ->
         ref = Process.monitor(pid)
         state = %{state | sessions: Map.put(sessions, session_id, {session_name, ref})}

--- a/lib/hermes/server/transport/sse/plug.ex
+++ b/lib/hermes/server/transport/sse/plug.ex
@@ -22,11 +22,11 @@ if Code.ensure_loaded?(Plug) do
 
         scope "/mcp" do
           pipe_through :mcp
-          
+
           # SSE endpoint
-          get "/sse", Hermes.Server.Transport.SSE.Plug, 
+          get "/sse", Hermes.Server.Transport.SSE.Plug,
             server: :your_server_name, mode: :sse
-          
+
           # POST endpoint
           post "/messages", Hermes.Server.Transport.SSE.Plug,
             server: :your_server_name, mode: :post
@@ -40,7 +40,7 @@ if Code.ensure_loaded?(Plug) do
           mode: :sse,
           at: "/sse",
           method_whitelist: ["GET"]
-          
+
         plug Hermes.Server.Transport.SSE.Plug,
           server: :your_server_name,
           mode: :post,
@@ -52,6 +52,7 @@ if Code.ensure_loaded?(Plug) do
     - `:server` - The server process name (required)
     - `:mode` - Either `:sse` or `:post` to determine endpoint behavior (required)
     - `:timeout` - Request timeout in milliseconds (default: 30000)
+    - `:registry` - The registry to use. See `Hermes.Server.Registry.Adapter` for more information (default: `Hermes.Server.Registry`)
 
     ## Security Features
 
@@ -76,7 +77,6 @@ if Code.ensure_loaded?(Plug) do
     alias Hermes.MCP.Error
     alias Hermes.MCP.ID
     alias Hermes.MCP.Message
-    alias Hermes.Server.Registry, as: ServerRegistry
     alias Hermes.Server.Transport.SSE
     alias Hermes.SSE.Streaming
     alias Plug.Conn.Unfetched
@@ -96,7 +96,8 @@ if Code.ensure_loaded?(Plug) do
         raise ArgumentError, "SSE.Plug requires :mode to be either :sse or :post"
       end
 
-      transport = ServerRegistry.transport(server, :sse)
+      registry = Keyword.get(opts, :registry, Hermes.Server.Registry)
+      transport = registry.transport(server, :sse)
       timeout = Keyword.get(opts, :timeout, @default_timeout)
 
       %{

--- a/lib/hermes/server/transport/streamable_http/plug.ex
+++ b/lib/hermes/server/transport/streamable_http/plug.ex
@@ -35,6 +35,7 @@ if Code.ensure_loaded?(Plug) do
     - `:server` - The server process name (required)
     - `:session_header` - Custom header name for session ID (default: "mcp-session-id")
     - `:timeout` - Request timeout in milliseconds (default: 30000)
+    - `:registry` - The registry to use. See `Hermes.Server.Registry.Adapter` for more information (default: `Hermes.Server.Registry`)
 
     ## Security Features
 
@@ -61,7 +62,6 @@ if Code.ensure_loaded?(Plug) do
     alias Hermes.MCP.Error
     alias Hermes.MCP.ID
     alias Hermes.MCP.Message
-    alias Hermes.Server.Registry, as: ServerRegistry
     alias Hermes.Server.Transport.StreamableHTTP
     alias Hermes.SSE.Streaming
     alias Plug.Conn.Unfetched
@@ -76,7 +76,8 @@ if Code.ensure_loaded?(Plug) do
     @impl Plug
     def init(opts) do
       server = Keyword.fetch!(opts, :server)
-      transport = ServerRegistry.transport(server, :streamable_http)
+      registry = Keyword.get(opts, :registry, Hermes.Server.Registry)
+      transport = registry.transport(server, :streamable_http)
       session_header = Keyword.get(opts, :session_header, @default_session_header)
       timeout = Keyword.get(opts, :timeout, @default_timeout)
 

--- a/test/hermes/server/transport/sse/plug_test.exs
+++ b/test/hermes/server/transport/sse/plug_test.exs
@@ -42,6 +42,17 @@ defmodule Hermes.Server.Transport.SSE.PlugTest do
 
       assert transport == registry.transport(StubServer, :sse)
     end
+
+    test "uses custom registry when provided" do
+      start_supervised!(MockCustomRegistry)
+      assert Process.whereis(MockCustomRegistry)
+
+      opts = SSEPlug.init(server: StubServer, mode: :sse, registry: MockCustomRegistry)
+
+      expected_transport = MockCustomRegistry.transport(StubServer, :sse)
+
+      assert opts.transport == expected_transport
+    end
   end
 
   describe "SSE endpoint" do

--- a/test/hermes/server/transport/streamable_http/plug_test.exs
+++ b/test/hermes/server/transport/streamable_http/plug_test.exs
@@ -41,6 +41,17 @@ defmodule Hermes.Server.Transport.StreamableHTTP.PlugTest do
 
       assert transport == registry.transport(StubServer, :streamable_http)
     end
+
+    test "uses custom registry when provided" do
+      start_supervised!(MockCustomRegistry)
+      assert Process.whereis(MockCustomRegistry)
+
+      opts = StreamableHTTPPlug.init(server: StubServer, mode: :streamable_http, registry: MockCustomRegistry)
+
+      expected_transport = MockCustomRegistry.transport(StubServer, :streamable_http)
+
+      assert opts.transport == expected_transport
+    end
   end
 
   describe "GET endpoint" do

--- a/test/support/mock_custom_registry.ex
+++ b/test/support/mock_custom_registry.ex
@@ -1,0 +1,77 @@
+defmodule MockCustomRegistry do
+  @moduledoc false
+  @behaviour Hermes.Server.Registry.Adapter
+
+  alias Hermes.Server.Registry.Adapter
+
+  @impl true
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {GenServer, :start_link, [__MODULE__, opts, [name: __MODULE__]]},
+      type: :worker,
+      restart: :permanent,
+      shutdown: 500
+    }
+  end
+
+  @impl Adapter
+  def transport(server, transport_type) do
+    {:via, __MODULE__, {:transport, server, transport_type}}
+  end
+
+  @impl Adapter
+  def server(server_module) do
+    {:via, __MODULE__, {:server, server_module}}
+  end
+
+  @impl Adapter
+  def server_session(server_module, session_id) do
+    {:via, __MODULE__, {:server_session, server_module, session_id}}
+  end
+
+  @impl Adapter
+  def supervisor(kind, server_module) do
+    {:via, __MODULE__, {:supervisor, kind, server_module}}
+  end
+
+  @impl Adapter
+  def whereis_server(server_module) do
+    case :ets.lookup(__MODULE__, {:server, server_module}) do
+      [{_, pid}] -> pid
+      [] -> nil
+    end
+  end
+
+  @impl Adapter
+  def whereis_server_session(server_module, session_id) do
+    case :ets.lookup(__MODULE__, {:server_session, server_module, session_id}) do
+      [{_, pid}] -> pid
+      [] -> nil
+    end
+  end
+
+  @impl Adapter
+  def whereis_transport(server_module, transport_type) do
+    case :ets.lookup(__MODULE__, {:transport, server_module, transport_type}) do
+      [{_, pid}] -> pid
+      [] -> nil
+    end
+  end
+
+  @impl Adapter
+  def whereis_supervisor(kind, server_module) do
+    case :ets.lookup(__MODULE__, {:supervisor, kind, server_module}) do
+      [{_, pid}] -> pid
+      [] -> nil
+    end
+  end
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  def init(_opts) do
+    {:ok, %{}}
+  end
+end


### PR DESCRIPTION
## Problem

There are leftover hardcoded `Hermes.Server.Registry` in transport plugs and the base server. This was preventing me from using a custom Horde-based registry, causing `ArgumentError: unknown registry` errors in multi-node setups.

## Solution

I have verified that this solution works in production using our fork.

- Added optional `registry` parameter to `Hermes.Server.Transport.SSE.Plug` and `Hermes.Server.Transport.StreamableHTTP.Plug`. The parameter defaults to `Hermes.Server.Registry` for backward compatibility.
- Updated `Hermes.Server.Base` to pass registry to session management.

**Usage:**
```elixir
# Before
get "/sse", Hermes.Server.Transport.SSE.Plug,
  server: MyServer, mode: :sse

# After (with custom registry)
get "/sse", Hermes.Server.Transport.SSE.Plug,
  server: MyServer, mode: :sse, registry: MyApp.HordeRegistry
```

## Rationale

This seemed like the simplest (and only) way to fix these issues.