### PR TITLE
fix: normalize transport api

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,16 @@ end
 
 # Define your tool
 defmodule MyApp.MCPServer.EchoTool do
-  @moduledoc "THis tool echoes everything the user says to the LLM"
+  @moduledoc "This tool echoes everything the user says to the LLM"
 
   use Hermes.Server.Component, type: :tool
 
   alias Hermes.Server.Response
 
   schema do
-    field :text, {:required, {:string, {:max, 500}}}, description: "The text to be echoed, max of 500 chars"
+    field :text, {:string, {:max, 500}},
+      description: "The text to be echoed, max of 500 chars",
+      required: true
   end
 
   @impl true
@@ -63,8 +65,11 @@ end
 # Add to your application supervisor
 children = [
   Hermes.Server.Registry,
-  {MyApp.MCPServer, transport: :stdio}
+  {MyApp.MCPServer, transport: :streamable_http}
 ]
+
+# Add to your Plug/Phoenix router (if using HTTP)
+forward "/mcp", Hermes.Server.Transport.StreamableHTTP.Plug, server: MyApp.MCPServer
 ```
 
 ### Client  

--- a/lib/hermes/server/supervisor.ex
+++ b/lib/hermes/server/supervisor.ex
@@ -110,7 +110,7 @@ defmodule Hermes.Server.Supervisor do
   @impl true
   def init(opts) do
     server = Keyword.fetch!(opts, :module)
-    transport = Keyword.fetch!(opts, :transport)
+    transport = normalize_transport(Keyword.fetch!(opts, :transport))
     init_arg = Keyword.fetch!(opts, :init_arg)
     registry = Keyword.fetch!(opts, :registry)
 
@@ -146,6 +146,9 @@ defmodule Hermes.Server.Supervisor do
       :ignore
     end
   end
+
+  defp normalize_transport(t) when t in [:stdio, StubTransport], do: t
+  defp normalize_transport(t) when t in ~w(sse streamable_http)a, do: {t, []}
 
   if Mix.env() == :test do
     defp parse_transport_child(StubTransport = kind, server, registry) do

--- a/pages/error_handling.md
+++ b/pages/error_handling.md
@@ -41,7 +41,7 @@ All errors have:
 ## Handling Client Responses
 
 ```elixir
-case Hermes.Client.call_tool(client, "search", %{query: "test"}) do
+case MyApp.MCPClient.call_tool("search", %{query: "test"}) do
   # Success
   {:ok, %Hermes.MCP.Response{is_error: false, result: result}} ->
     IO.puts("Success: #{inspect(result)}")
@@ -62,7 +62,7 @@ end
 
 ```elixir
 # Set custom timeout (default is 30 seconds)
-case Hermes.Client.call_tool(client, "slow_tool", %{}, timeout: 60_000) do
+case MyApp.MCPClient.call_tool("slow_tool", %{}, timeout: 60_000) do
   {:error, %Hermes.MCP.Error{reason: :timeout}} ->
     IO.puts("Request timed out")
   

--- a/pages/progress_tracking.md
+++ b/pages/progress_tracking.md
@@ -25,7 +25,7 @@ Any client API request can include progress tracking options. Internally, these 
 
 ```elixir
 # Make a request with progress tracking
-Hermes.Client.read_resource(client, "resource-uri",
+MyApp.MCPClient.read_resource("resource-uri",
   progress: [token: progress_token]
 )
 ```
@@ -57,5 +57,5 @@ callback = fn ^token, progress, total ->
   IO.puts("Progress: #{progress}/#{total || "unknown"}")
 end
 
-Hermes.Client.list_tools(client, progress: [token: token, callback: callback])
+MyApp.MCPClient.list_tools(progress: [token: token, callback: callback])
 ```

--- a/pages/server_quickstart.md
+++ b/pages/server_quickstart.md
@@ -62,13 +62,15 @@ defmodule MyApp.MCPServer.Tools.Greeter do
 
   use Hermes.Server.Component, type: :tool
 
+  alias Hermes.Server.Response
+
   schema do
-    %{name: {:required, :string}}
+    field :name, :string, required: true
   end
 
   @impl true
   def execute(%{name: name}, frame) do
-    {:ok, "Hello, #{name}! Welcome to MCP!", frame}
+    {:reply, Response.text(Response.tool(), "Hello, #{name}! Welcome to MCP!"), frame}
   end
 end
 ```


### PR DESCRIPTION
## Problem

`sse` and `streamable_http` transport can have additional options passed as a tuple into the child_spec of supervision tree.

so users was being requried to pass `{:sse, []}` if no additional options is needed, causing confusion about how to configure transport layer, conflicting with the simple `:stdio`

## Solution

normalize the transport, so users can now pass only `transport: :sse` or `transport: :streamable_http`

## Rationale

Close #145
