### PR TITLE
fix: allow users to control external process messages

### DIFF
--- a/lib/hermes/server.ex
+++ b/lib/hermes/server.ex
@@ -192,14 +192,11 @@ defmodule Hermes.Server do
         Handlers.handle(request, __MODULE__, frame)
       end
 
-      @impl Hermes.Server.Behaviour
-      def handle_notification(_notif, frame), do: {:noreply, frame}
-
       unquote(maybe_define_server_info(env.module, opts[:name], opts[:version]))
       unquote(maybe_define_server_capabilities(env.module, opts[:capabilities]))
       unquote(maybe_define_protocol_versions(env.module, opts[:protocol_versions]))
 
-      defoverridable handle_request: 2, handle_notification: 2
+      defoverridable handle_request: 2
     end
   end
 


### PR DESCRIPTION
## Problem

users could not leverage `handle_info/2` genserver callback to receive external process messages for example manage timers or react to other processes messages

## Solution

add catch-all clause on `Hermes.Server.Base` that routes directly to the user defined module

## Rationale

this is part of a sequence of PRs that will try to simplify the final API for users, being even more similar to the LiveView architecture, discussed on #141
