### PR TITLE
fix: server behaviour with optional callbacks

### DIFF
--- a/lib/hermes/server/base.ex
+++ b/lib/hermes/server/base.ex
@@ -52,7 +52,6 @@ defmodule Hermes.Server.Base do
 
   use GenServer
 
-  import Hermes.Server.Behaviour, only: [impl_by?: 1]
   import Peri
 
   alias Hermes.Logging
@@ -285,10 +284,6 @@ defmodule Hermes.Server.Base do
 
   @impl GenServer
   def init(%{module: module} = opts) do
-    if not impl_by?(module) do
-      raise ArgumentError, "Module #{inspect(module)} does not implement Hermes.Server.Behaviour"
-    end
-
     server_info = module.server_info()
     capabilities = module.server_capabilities()
     protocol_versions = module.supported_protocol_versions()

--- a/lib/hermes/server/behaviour.ex
+++ b/lib/hermes/server/behaviour.ex
@@ -222,30 +222,14 @@ defmodule Hermes.Server.Behaviour do
   @callback supported_protocol_versions() :: [String.t()]
 
   @doc """
-  Checks if the given module implements the Hermes.Server.Behaviour interface.
+  Invoked to handle all other external messages received for example from other processes
 
-  ## Parameters
-
-  - `module`: The module to be checked.
-
-  ## Returns
-
-  - boolean
-
-  ## Examples
-
-      iex> Hermes.Server.Behaviour.impl_by?(MyApp.MCPServer)
-      true
-
-      iex> Hermes.Server.Behaviour.impl_by?(String)
-      false
+  Works exactly the same as `GenServer.handle_info`
   """
-  def impl_by?(module) when is_atom(module) do
-    if Code.ensure_loaded?(module) do
-      callbacks = __MODULE__.behaviour_info(:callbacks)
-      functions = module.__info__(:functions)
+  @callback handle_info(event :: term, Frame.t()) ::
+              {:noreply, Frame.t()}
+              | {:noreply, Frame.t(), GenServer.timeout() | :hibernate | {:continue, arg :: term}}
+              | {:stop, reason :: term, Frame.t()}
 
-      Enum.empty?(callbacks -- functions)
-    end
-  end
+  @optional_callbacks handle_notification: 2, handle_info: 2
 end

--- a/lib/hermes/server/supervisor.ex
+++ b/lib/hermes/server/supervisor.ex
@@ -149,6 +149,7 @@ defmodule Hermes.Server.Supervisor do
 
   defp normalize_transport(t) when t in [:stdio, StubTransport], do: t
   defp normalize_transport(t) when t in ~w(sse streamable_http)a, do: {t, []}
+  defp normalize_transport({t, opts}) when t in ~w(sse streamable_http)a, do: {t, opts}
 
   if Mix.env() == :test do
     defp parse_transport_child(StubTransport = kind, server, registry) do

--- a/priv/dev/upcase/lib/upcase/application.ex
+++ b/priv/dev/upcase/lib/upcase/application.ex
@@ -9,7 +9,7 @@ defmodule Upcase.Application do
   def start(_type, _args) do
     children = [
       Hermes.Server.Registry,
-      {Upcase.Server, transport: {:streamable_http, []}},
+      {Upcase.Server, transport: {:streamable_http, start: true}},
       {Bandit, plug: Upcase.Router}
     ]
 

--- a/priv/dev/upcase/lib/upcase/server.ex
+++ b/priv/dev/upcase/lib/upcase/server.ex
@@ -31,6 +31,19 @@ defmodule Upcase.Server do
 
   @impl true
   def init(:ok, frame) do
-    {:ok, frame}
+    schedule_hello()
+    {:ok, assign(frame, counter: 0)}
+  end
+
+  @impl true
+  def handle_info(:hello, frame) do
+    schedule_hello()
+    frame = assign(frame, counter: frame.assigns.counter + 1)
+    IO.puts("HELLO FROM UPCASE (on #{inspect(self())})! COUNTING: #{frame.assigns.counter}")
+    {:noreply, frame}
+  end
+
+  defp schedule_hello do
+    Process.send_after(self(), :hello, 1_650)
   end
 end


### PR DESCRIPTION
## Problem

N/A

## Solution

implement an example of the new `handle_info/2` callback on server implementation, and fixed a missing pattern matching clause on `Hermes.Server.Supervisor` preventing starting server with additional options for transport...

## Rationale

this's part of a series of PRs that aims to reduce exposed internal complexity of hermes to final users, discussed on #141
