### PR TITLE
feat: runtime server components, simplified api

### DIFF
--- a/lib/hermes.ex
+++ b/lib/hermes.ex
@@ -43,4 +43,9 @@ defmodule Hermes do
   def genserver_name(val) do
     {:error, "#{inspect(val, pretty: true)} is not a valid name for a GenServer"}
   end
+
+  @doc false
+  def exported?(m, f, a) do
+    function_exported?(m, f, a) or (Code.ensure_loaded?(m) and function_exported?(m, f, a))
+  end
 end

--- a/lib/hermes/server.ex
+++ b/lib/hermes/server.ex
@@ -329,7 +329,8 @@ defmodule Hermes.Server do
                       handle_tool_call: 3,
                       handle_resource_read: 2,
                       handle_prompt_get: 3,
-                      handle_request: 2
+                      handle_request: 2,
+                      init: 2
 
   @doc """
   Checks if the MCP session has been initialized.
@@ -469,8 +470,9 @@ defmodule Hermes.Server do
 
     if Hermes.exported?(mod, :input_schema, 0) do
       validate_input = fn params ->
-        schema = mod.__mcp_raw_schema__()
-        Peri.validate(schema, params)
+        mod.__mcp_raw_schema__()
+        |> Component.__clean_schema_for_peri__()
+        |> Peri.validate(params)
       end
 
       [
@@ -491,8 +493,9 @@ defmodule Hermes.Server do
   def parse_components({:prompt, name, mod}) do
     if Hermes.exported?(mod, :arguments, 0) do
       validate_input = fn params ->
-        schema = mod.__mcp_raw_schema__()
-        Peri.validate(schema, params)
+        mod.__mcp_raw_schema__()
+        |> Component.__clean_schema_for_peri__()
+        |> Peri.validate(params)
       end
 
       [

--- a/lib/hermes/server.ex
+++ b/lib/hermes/server.ex
@@ -89,6 +89,9 @@ defmodule Hermes.Server do
   """
 
   alias Hermes.Server.Component
+  alias Hermes.Server.Component.Prompt
+  alias Hermes.Server.Component.Resource
+  alias Hermes.Server.Component.Tool
   alias Hermes.Server.ConfigurationError
   alias Hermes.Server.Frame
   alias Hermes.Server.Handlers
@@ -104,61 +107,82 @@ defmodule Hermes.Server do
   @type server_capabilities :: map()
 
   @doc """
-  Initializes the server when it starts up.
+  Called after a client requests a `initialize` request.
 
-  This callback sets the stage for your MCP server. It's called once when the server
-  process starts and gives you the opportunity to set up initial state, load configuration,
-  establish connections to external services, or perform any other setup tasks your
-  server needs before it can start handling MCP protocol messages.
+  This callback is invoked while the MCP handshake starts and so the client may not sent
+  the `notifications/initialized` message yet. For checking if the notification was already sent
+  and the MCP handshare was successfully completed, you can call the `initialized?/1` function.
 
-  The frame parameter provides a structured way to manage your server's state throughout
-  its lifecycle. You can store configuration, track active subscriptions, cache resources,
-  or maintain any other stateful data your server needs to operate effectively.
+  It receives the client's information and
+  the current frame, allowing you to perform client-specific setup, validate capabilities,
+  or prepare resources based on the connected client.
 
-  This follows the standard GenServer initialization pattern, so you can return various
-  tuples to control the server's startup behavior - from simple success to requesting
-  hibernation for memory optimization or scheduling immediate work with :continue.
+  The client_info parameter contains details about the connected client including its
+  name, version, and any additional metadata. Use this to tailor your server's behavior
+  to specific client implementations or versions.
   """
-  @callback init(init_arg :: term(), Frame.t()) ::
-              {:ok, Frame.t()}
-              | {:ok, Frame.t(), timeout | :hibernate | {:continue, arg :: term}}
-              | {:stop, reason :: term()}
-              | :ignore
+  @callback init(client_info :: map(), Frame.t()) :: {:ok, Frame.t()}
 
   @doc """
-  Handles incoming MCP requests from clients.
+  Handles a tool call request.
 
-  This callback is the heart of your MCP server's request handling. When a client sends a request,
-  this function determines how to process it and what response to send back. The MCP protocol
-  defines a standard set of request methods that clients can invoke:
+  This callback is invoked when a client calls a specific tool. It receives the tool name,
+  the arguments provided by the client, and the current frame. Developers's implementation should
+  execute the tool's logic and return the result.
 
-  **Core Protocol Requests:**
-  - `initialize` - Establishes the connection, exchanges capabilities between client and server
-  - `ping` - Health check to verify the server is responsive
+  This callback handles both module-based components (registered with `component`) and
+  runtime components (registered with `Frame.register_tool/3`). For module-based tools,
+  the framework automatically generates pattern-matched clauses during compilation.
+  """
+  @callback handle_tool_call(name :: String.t(), arguments :: map(), Frame.t()) ::
+              {:reply, result :: term(), Frame.t()}
+              | {:error, mcp_error(), Frame.t()}
 
-  **Resource Management:**
-  - `resources/list` - Returns available resources the server can provide
-  - `resources/templates/list` - Returns URI templates for dynamic resources
-  - `resources/read` - Retrieves content of a specific resource
-  - `resources/subscribe` - Subscribes to updates for a resource
-  - `resources/unsubscribe` - Cancels a resource subscription
+  @doc """
+  Handles a resource read request.
 
-  **Tool Execution:**
-  - `tools/list` - Returns available tools the server can execute
-  - `tools/call` - Executes a specific tool with provided arguments
+  This callback is invoked when a client requests to read a specific resource. It receives
+  the resource URI and the current frame. Developer's implementation should retrieve and return
+  the resource content.
 
-  **Prompt Templates:**
-  - `prompts/list` - Returns available prompt templates
-  - `prompts/get` - Retrieves a specific prompt with filled arguments
+  This callback handles both module-based components (registered with `component`) and
+  runtime components (registered with `Frame.register_resource/3`). For module-based resources,
+  the framework automatically generates pattern-matched clauses during compilation.
+  """
+  @callback handle_resource_read(uri :: String.t(), Frame.t()) ::
+              {:reply, content :: map(), Frame.t()}
+              | {:error, mcp_error(), Frame.t()}
 
-  **Other Capabilities:**
-  - `logging/setLevel` - Adjusts the server's logging verbosity
-  - `completion/complete` - Provides autocompletion suggestions
+  @doc """
+  Handles a prompt get request.
 
-  The server should respond to supported methods and return appropriate errors for
-  unsupported ones. When using `use Hermes.Server`, most of these handlers are
-  automatically implemented based on your configured capabilities and registered
-  components.
+  This callback is invoked when a client requests a specific prompt template. It receives
+  the prompt name, any arguments to fill into the template, and the current frame.
+
+  This callback handles both module-based components (registered with `component`) and
+  runtime components (registered with `Frame.register_prompt/3`). For module-based prompts,
+  the framework automatically generates pattern-matched clauses during compilation.
+  """
+  @callback handle_prompt_get(name :: String.t(), arguments :: map(), Frame.t()) ::
+              {:reply, messages :: list(), Frame.t()}
+              | {:error, mcp_error(), Frame.t()}
+
+  @doc """
+  Low-level handler for any MCP request.
+
+  This is an advanced callback that gives you complete control over request handling.
+  When implemented, it bypasses the automatic routing to `handle_tool_call/3`,
+  `handle_resource_read/2`, and `handle_prompt_get/3` and all other requests that are
+  handled internally, like `tools/list` and `logging/setLevel`.
+
+  Use this when you need to:
+  - Implement custom request methods beyond the standard MCP protocol
+  - Add middleware-like processing before requests reach specific handlers
+  - Override the framework's default request routing behavior
+
+  Note: If you implement this callback, you become responsible for handling ALL
+  MCP requests, including standard protocol methods like `tools/list`, `resources/list`, etc.
+  Consider using the specific callbacks instead unless you need this level of control.
   """
   @callback handle_request(request :: request(), state :: Frame.t()) ::
               {:reply, response :: response(), new_state :: Frame.t()}
@@ -297,23 +321,37 @@ defmodule Hermes.Server do
   """
   @callback terminate(reason :: term, Frame.t()) :: term
 
-  @optional_callbacks handle_notification: 2, handle_info: 2, handle_call: 3, handle_cast: 2, terminate: 2
+  @optional_callbacks handle_notification: 2,
+                      handle_info: 2,
+                      handle_call: 3,
+                      handle_cast: 2,
+                      terminate: 2,
+                      handle_tool_call: 3,
+                      handle_resource_read: 2,
+                      handle_prompt_get: 3,
+                      handle_request: 2
 
   @doc """
-  Starts a server with its supervision tree.
+  Checks if the MCP session has been initialized.
+
+  Returns true if the client has completed the initialization handshake and sent
+  the `notifications/initialized` message. This is useful for guarding operations
+  that require an active session.
 
   ## Examples
 
-      # Start with default options
-      Hermes.Server.start_link(MyServer, :ok, transport: :stdio)
-      
-      # Start with custom name
-      Hermes.Server.start_link(MyServer, %{}, 
-        transport: :stdio,
-        name: {:local, :my_server}
-      )
+      def handle_info(:check_status, frame) do
+        if Hermes.Server.initialized?(frame) do
+          # Perform operations requiring initialized session
+          {:noreply, frame}
+        else
+          # Wait for initialization
+          {:noreply, frame}
+        end
+      end
   """
-  defdelegate start_link(mod, init_arg, opts), to: Hermes.Server.Supervisor
+  @spec initialized?(Frame.t()) :: boolean()
+  def initialized?(%Frame{initialized: initialized}), do: initialized
 
   @doc false
   defguard is_server_capability(capability) when capability in @server_capabilities
@@ -326,7 +364,7 @@ defmodule Hermes.Server do
     quote do
       @behaviour Hermes.Server
 
-      import Hermes.Server, only: [component: 1, component: 2]
+      import Hermes.Server, only: [component: 1, component: 2, initialized?: 1]
 
       import Hermes.Server.Base,
         only: [
@@ -355,7 +393,7 @@ defmodule Hermes.Server do
       def child_spec(opts) do
         %{
           id: __MODULE__,
-          start: {__MODULE__, :start_link, [opts]},
+          start: {Hermes.Server.Supervisor, :start_link, [__MODULE__, opts]},
           type: :supervisor,
           restart: :permanent
         }
@@ -402,14 +440,11 @@ defmodule Hermes.Server do
     components = Module.get_attribute(env.module, :components, [])
     opts = get_server_opts(env.module)
 
-    tools = for {:tool, name, mod} <- components, do: {name, mod}
-    prompts = for {:prompt, name, mod} <- components, do: {name, mod}
-    resources = for {:resource, name, mod} <- components, do: {name, mod}
-
     quote do
-      def __components__(:tool), do: unquote(Macro.escape(tools))
-      def __components__(:prompt), do: unquote(Macro.escape(prompts))
-      def __components__(:resource), do: unquote(Macro.escape(resources))
+      def __components__, do: Hermes.Server.parse_components(unquote(Macro.escape(components)))
+      def __components__(:tool), do: Enum.filter(__components__(), &match?(%Tool{}, &1))
+      def __components__(:prompt), do: Enum.filter(__components__(), &match?(%Prompt{}, &1))
+      def __components__(:resource), do: Enum.filter(__components__(), &match?(%Resource{}, &1))
 
       @impl Hermes.Server
       def handle_request(%{} = request, frame) do
@@ -421,6 +456,72 @@ defmodule Hermes.Server do
       unquote(maybe_define_protocol_versions(env.module, opts[:protocol_versions]))
 
       defoverridable handle_request: 2
+    end
+  end
+
+  @doc false
+  def parse_components(components) when is_list(components) do
+    Enum.flat_map(components, &parse_components/1)
+  end
+
+  def parse_components({:tool, name, mod}) do
+    annotations = if Hermes.exported?(mod, :annotations, 0), do: mod.annotations()
+
+    if Hermes.exported?(mod, :input_schema, 0) do
+      validate_input = fn params ->
+        schema = mod.__mcp_raw_schema__()
+        Peri.validate(schema, params)
+      end
+
+      [
+        %Tool{
+          name: name,
+          description: Component.get_description(mod),
+          input_schema: mod.input_schema(),
+          annotations: annotations,
+          handler: mod,
+          validate_input: validate_input
+        }
+      ]
+    else
+      []
+    end
+  end
+
+  def parse_components({:prompt, name, mod}) do
+    if Hermes.exported?(mod, :arguments, 0) do
+      validate_input = fn params ->
+        schema = mod.__mcp_raw_schema__()
+        Peri.validate(schema, params)
+      end
+
+      [
+        %Prompt{
+          name: name,
+          description: Component.get_description(mod),
+          arguments: mod.arguments(),
+          handler: mod,
+          validate_input: validate_input
+        }
+      ]
+    else
+      []
+    end
+  end
+
+  def parse_components({:resource, name, mod}) do
+    if Hermes.exported?(mod, :uri, 0) do
+      [
+        %Resource{
+          uri: mod.uri(),
+          name: name,
+          description: Component.get_description(mod),
+          mime_type: mod.mime_type(),
+          handler: mod
+        }
+      ]
+    else
+      []
     end
   end
 

--- a/lib/hermes/server/component/prompt.ex
+++ b/lib/hermes/server/component/prompt.ex
@@ -94,7 +94,6 @@ defmodule Hermes.Server.Component.Prompt do
           validate_input: (map -> {:ok, map} | {:error, [Peri.Error.t()]}) | nil
         }
 
-  @derive {JSON.Encoder, except: [:handler, :validate_input]}
   defstruct [:name, description: nil, arguments: nil, handler: nil, validate_input: nil]
 
   @doc """
@@ -154,4 +153,14 @@ defmodule Hermes.Server.Component.Prompt do
               {:reply, response :: Response.t(), new_state :: Frame.t()}
               | {:noreply, new_state :: Frame.t()}
               | {:error, error :: Error.t(), new_state :: Frame.t()}
+
+  defimpl JSON.Encoder, for: __MODULE__ do
+    alias Hermes.Server.Component.Prompt
+
+    def encode(%Prompt{} = prompt, _) do
+      prompt
+      |> Map.from_struct()
+      |> JSON.encode!()
+    end
+  end
 end

--- a/lib/hermes/server/component/prompt.ex
+++ b/lib/hermes/server/component/prompt.ex
@@ -86,6 +86,17 @@ defmodule Hermes.Server.Component.Prompt do
           optional(String.t()) => boolean()
         }
 
+  @type t :: %__MODULE__{
+          name: String.t(),
+          description: String.t() | nil,
+          arguments: map | nil,
+          handler: module | nil,
+          validate_input: (map -> {:ok, map} | {:error, [Peri.Error.t()]}) | nil
+        }
+
+  @derive {JSON.Encoder, except: [:handler, :validate_input]}
+  defstruct [:name, description: nil, arguments: nil, handler: nil, validate_input: nil]
+
   @doc """
   Returns the list of arguments this prompt accepts.
 
@@ -143,30 +154,4 @@ defmodule Hermes.Server.Component.Prompt do
               {:reply, response :: Response.t(), new_state :: Frame.t()}
               | {:noreply, new_state :: Frame.t()}
               | {:error, error :: Error.t(), new_state :: Frame.t()}
-
-  @doc """
-  Converts a prompt module into the MCP protocol format.
-  """
-  @spec to_protocol(module()) :: map()
-  def to_protocol(prompt_module) do
-    %{
-      "name" => prompt_module.name(),
-      "description" => prompt_module.description(),
-      "arguments" => prompt_module.arguments()
-    }
-  end
-
-  @doc """
-  Validates that a module implements the Prompt behaviour.
-  """
-  @spec implements?(module()) :: boolean()
-  def implements?(module) do
-    behaviours =
-      :attributes
-      |> module.__info__()
-      |> Keyword.get(:behaviour, [])
-      |> List.flatten()
-
-    __MODULE__ in behaviours
-  end
 end

--- a/lib/hermes/server/component/resource.ex
+++ b/lib/hermes/server/component/resource.ex
@@ -85,7 +85,6 @@ defmodule Hermes.Server.Component.Resource do
           handler: module | nil
         }
 
-  @derive {JSON.Encoder, except: [:handler]}
   defstruct [:uri, :name, description: nil, mime_type: "text/plain", handler: nil]
 
   @doc """
@@ -136,4 +135,14 @@ defmodule Hermes.Server.Component.Resource do
               {:reply, response :: Response.t(), new_state :: Frame.t()}
               | {:noreply, new_state :: Frame.t()}
               | {:error, error :: Error.t(), new_state :: Frame.t()}
+
+  defimpl JSON.Encoder, for: __MODULE__ do
+    alias Hermes.Server.Component.Resource
+
+    def encode(%Resource{} = resource, _) do
+      resource
+      |> Map.from_struct()
+      |> JSON.encode!()
+    end
+  end
 end

--- a/lib/hermes/server/component/resource.ex
+++ b/lib/hermes/server/component/resource.ex
@@ -77,6 +77,17 @@ defmodule Hermes.Server.Component.Resource do
   @type params :: map()
   @type content :: binary() | String.t()
 
+  @type t :: %__MODULE__{
+          uri: String.t(),
+          name: String.t(),
+          description: String.t() | nil,
+          mime_type: String.t(),
+          handler: module | nil
+        }
+
+  @derive {JSON.Encoder, except: [:handler]}
+  defstruct [:uri, :name, description: nil, mime_type: "text/plain", handler: nil]
+
   @doc """
   Returns the URI that identifies this resource.
 
@@ -125,31 +136,4 @@ defmodule Hermes.Server.Component.Resource do
               {:reply, response :: Response.t(), new_state :: Frame.t()}
               | {:noreply, new_state :: Frame.t()}
               | {:error, error :: Error.t(), new_state :: Frame.t()}
-
-  @doc """
-  Converts a resource module into the MCP protocol format.
-  """
-  @spec to_protocol(module()) :: map()
-  def to_protocol(resource_module) do
-    %{
-      "uri" => resource_module.uri(),
-      "name" => resource_module.name(),
-      "description" => resource_module.description(),
-      "mimeType" => resource_module.mime_type()
-    }
-  end
-
-  @doc """
-  Validates that a module implements the Resource behaviour.
-  """
-  @spec implements?(module()) :: boolean()
-  def implements?(module) do
-    behaviours =
-      :attributes
-      |> module.__info__()
-      |> Keyword.get(:behaviour, [])
-      |> List.flatten()
-
-    __MODULE__ in behaviours
-  end
 end

--- a/lib/hermes/server/component/tool.ex
+++ b/lib/hermes/server/component/tool.ex
@@ -73,7 +73,6 @@ defmodule Hermes.Server.Component.Tool do
           validate_input: (map -> {:ok, map} | {:error, [Peri.Error.t()]}) | nil
         }
 
-  @derive {JSON.Encoder, except: [:handler, :validate_input]}
   defstruct [:name, description: nil, input_schema: nil, annotations: nil, handler: nil, validate_input: nil]
 
   @doc """
@@ -139,4 +138,18 @@ defmodule Hermes.Server.Component.Tool do
               | {:error, error :: Error.t(), new_state :: Frame.t()}
 
   @optional_callbacks annotations: 0
+
+  defimpl JSON.Encoder, for: __MODULE__ do
+    alias Hermes.Server.Component.Tool
+
+    def encode(%Tool{} = tool, _) do
+      %{
+        "name" => tool.name,
+        "description" => tool.description,
+        "inputSchema" => tool.input_schema
+      }
+      |> then(&if a = tool.annotations, do: Map.put(&1, "annotations", a), else: &1)
+      |> JSON.encode!()
+    end
+  end
 end

--- a/lib/hermes/server/handlers/tools.ex
+++ b/lib/hermes/server/handlers/tools.ex
@@ -25,10 +25,7 @@ defmodule Hermes.Server.Handlers.Tools do
           {:reply, map(), Frame.t()} | {:error, Error.t(), Frame.t()}
   def handle_list(frame, server_module) do
     tools = server_module.__components__(:tool) ++ Frame.get_tools(frame)
-    protocol_version = Frame.get_protocol_version(frame) || "2024-11-05"
-    response = %{"tools" => Enum.map(tools, &parse_tool_definition(&1, protocol_version))}
-
-    {:reply, response, frame}
+    {:reply, %{"tools" => tools}, frame}
   end
 
   @doc """
@@ -61,14 +58,6 @@ defmodule Hermes.Server.Handlers.Tools do
   # Private functions
 
   defp find_tool_module(tools, name), do: Enum.find(tools, &(&1.name == name))
-
-  defp parse_tool_definition(%Tool{} = tool, protocol_version) do
-    if Hermes.Protocol.supports_feature?(protocol_version, :tool_annotations) do
-      tool
-    else
-      tool |> Map.from_struct() |> Map.delete(:annotations)
-    end
-  end
 
   defp validate_params(params, %Tool{} = tool, frame) do
     with {:error, errors} <- tool.validate_input.(params) do

--- a/lib/hermes/server/handlers/tools.ex
+++ b/lib/hermes/server/handlers/tools.ex
@@ -2,8 +2,8 @@ defmodule Hermes.Server.Handlers.Tools do
   @moduledoc false
 
   alias Hermes.MCP.Error
-  alias Hermes.Server.Component
   alias Hermes.Server.Component.Schema
+  alias Hermes.Server.Component.Tool
   alias Hermes.Server.Frame
   alias Hermes.Server.Response
 
@@ -24,7 +24,7 @@ defmodule Hermes.Server.Handlers.Tools do
   @spec handle_list(Frame.t(), module()) ::
           {:reply, map(), Frame.t()} | {:error, Error.t(), Frame.t()}
   def handle_list(frame, server_module) do
-    tools = server_module.__components__(:tool)
+    tools = server_module.__components__(:tool) ++ Frame.get_tools(frame)
     protocol_version = Frame.get_protocol_version(frame) || "2024-11-05"
     response = %{"tools" => Enum.map(tools, &parse_tool_definition(&1, protocol_version))}
 
@@ -47,11 +47,11 @@ defmodule Hermes.Server.Handlers.Tools do
   """
   @spec handle_call(map(), Frame.t(), module()) ::
           {:reply, map(), Frame.t()} | {:error, Error.t(), Frame.t()}
-  def handle_call(%{"params" => %{"name" => tool_name, "arguments" => params}}, frame, server_module) do
-    registered_tools = server_module.__components__(:tool)
+  def handle_call(%{"params" => %{"name" => tool_name, "arguments" => params}}, frame, server) do
+    registered_tools = server.__components__(:tool) ++ Frame.get_tools(frame)
 
     if tool = find_tool_module(registered_tools, tool_name) do
-      with {:ok, params} <- validate_params(params, tool, frame), do: forward_to(tool, params, frame)
+      with {:ok, params} <- validate_params(params, tool, frame), do: forward_to(server, tool, params, frame)
     else
       payload = %{message: "Tool not found: #{tool_name}"}
       {:error, Error.protocol(:invalid_params, payload), frame}
@@ -60,37 +60,38 @@ defmodule Hermes.Server.Handlers.Tools do
 
   # Private functions
 
-  defp find_tool_module(tools, name) do
-    Enum.find_value(tools, fn
-      {^name, module} -> module
-      _ -> nil
-    end)
-  end
+  defp find_tool_module(tools, name), do: Enum.find(tools, &(&1.name == name))
 
-  defp parse_tool_definition({name, module}, protocol_version) do
-    base = %{
-      "name" => name,
-      "description" => Component.get_description(module),
-      "inputSchema" => module.input_schema()
-    }
-
-    if Hermes.Protocol.supports_feature?(protocol_version, :tool_annotations) and
-         Code.ensure_loaded?(module) and function_exported?(module, :annotations, 0) do
-      Map.put(base, "annotations", module.annotations())
+  defp parse_tool_definition(%Tool{} = tool, protocol_version) do
+    if Hermes.Protocol.supports_feature?(protocol_version, :tool_annotations) do
+      tool
     else
-      base
+      tool |> Map.from_struct() |> Map.delete(:annotations)
     end
   end
 
-  defp validate_params(params, module, frame) do
-    with {:error, errors} <- module.mcp_schema(params) do
+  defp validate_params(params, %Tool{} = tool, frame) do
+    with {:error, errors} <- tool.validate_input.(params) do
       message = Schema.format_errors(errors)
       {:error, Error.protocol(:invalid_params, %{message: message}), frame}
     end
   end
 
-  defp forward_to(module, params, frame) do
-    case module.execute(params, frame) do
+  defp forward_to(server, %Tool{handler: nil} = tool, params, frame) do
+    case server.handle_tool(tool.name, params, frame) do
+      {:reply, %Response{} = response, frame} ->
+        {:reply, Response.to_protocol(response), frame}
+
+      {:noreply, frame} ->
+        {:reply, %{"content" => [], "isError" => false}, frame}
+
+      {:error, %Error{} = error, frame} ->
+        {:error, error, frame}
+    end
+  end
+
+  defp forward_to(_server, %Tool{handler: handler}, params, frame) do
+    case handler.execute(params, frame) do
       {:reply, %Response{} = response, frame} ->
         {:reply, Response.to_protocol(response), frame}
 

--- a/lib/hermes/server/session.ex
+++ b/lib/hermes/server/session.ex
@@ -1,19 +1,5 @@
 defmodule Hermes.Server.Session do
-  @moduledoc """
-  Manages state for the Hermes MCP server base implementation.
-
-  This module provides a structured representation of server state during the MCP lifecycle,
-  including initialization status, protocol negotiation, and server capabilities.
-
-  ## State Structure
-
-  Each server state includes:
-  - `protocol_version`: Negotiated MCP protocol version
-  - `frame`: Server frame (similar to LiveView socket)
-  - `initialized`: Whether the server has completed initialization
-  - `client_info`: Client information received during initialization
-  - `client_capabilities`: Client capabilities received during initialization
-  """
+  @moduledoc false
 
   use Agent, restart: :transient
 

--- a/lib/hermes/server/supervisor.ex
+++ b/lib/hermes/server/supervisor.ex
@@ -76,7 +76,6 @@ defmodule Hermes.Server.Supervisor do
   ## Parameters
 
     * `server` - The module implementing `Hermes.Server`
-    * `init_arg` - Argument passed to the server's `init/2` callback
     * `opts` - Options including:
       * `:transport` - Transport configuration (required)
       * `:name` - Supervisor name (optional, defaults to registered name)
@@ -99,11 +98,11 @@ defmodule Hermes.Server.Supervisor do
         session_idle_timeout: :timer.minutes(15)
       )
   """
-  @spec start_link(server :: module, init_arg :: term, list(start_option)) :: Supervisor.on_start()
-  def start_link(server, init_arg, opts) when is_atom(server) and is_list(opts) do
+  @spec start_link(server :: module, list(start_option)) :: Supervisor.on_start()
+  def start_link(server, opts) when is_atom(server) and is_list(opts) do
     registry = Keyword.get(opts, :registry, Hermes.Server.Registry)
     name = Keyword.get(opts, :name, registry.supervisor(server))
-    opts = Keyword.merge(opts, module: server, init_arg: init_arg, registry: registry)
+    opts = Keyword.merge(opts, module: server, registry: registry)
     Supervisor.start_link(__MODULE__, opts, name: name)
   end
 
@@ -111,7 +110,6 @@ defmodule Hermes.Server.Supervisor do
   def init(opts) do
     server = Keyword.fetch!(opts, :module)
     transport = normalize_transport(Keyword.fetch!(opts, :transport))
-    init_arg = Keyword.fetch!(opts, :init_arg)
     registry = Keyword.fetch!(opts, :registry)
 
     if should_start?(transport) do
@@ -124,7 +122,6 @@ defmodule Hermes.Server.Supervisor do
         module: server,
         name: server_name,
         transport: server_transport,
-        init_arg: init_arg,
         registry: registry
       ]
 

--- a/priv/dev/ascii/lib/ascii/mcp_server.ex
+++ b/priv/dev/ascii/lib/ascii/mcp_server.ex
@@ -11,15 +11,6 @@ defmodule Ascii.MCPServer do
   alias Hermes.MCP.Error
   require Logger
 
-  def start_link(opts \\ []) do
-    Hermes.Server.start_link(__MODULE__, :ok, opts)
-  end
-
-  @impl true
-  def init(:ok, frame) do
-    {:ok, frame}
-  end
-
   @impl true
   def handle_request(%{"method" => "tools/list"} = _request, state) do
     response = %{

--- a/priv/dev/echo-elixir/lib/echo_mcp/server.ex
+++ b/priv/dev/echo-elixir/lib/echo_mcp/server.ex
@@ -3,19 +3,5 @@ defmodule EchoMCP.Server do
 
   use Hermes.Server, name: "Echo Server", version: Echo.version(), capabilities: [:tools]
 
-  def start_link(opts) do
-    Hermes.Server.start_link(__MODULE__, :ok, opts)
-  end
-
   component(EchoMCP.Tools.Echo)
-
-  @impl true
-  def init(:ok, frame) do
-    {:ok, frame}
-  end
-
-  @impl true
-  def handle_notification(_, frame) do
-    {:noreply, frame}
-  end
 end

--- a/priv/dev/upcase/lib/upcase/server.ex
+++ b/priv/dev/upcase/lib/upcase/server.ex
@@ -5,9 +5,7 @@ defmodule Upcase.Server do
 
   use Hermes.Server
 
-  def start_link(opts \\ []) do
-    Hermes.Server.start_link(__MODULE__, :ok, opts)
-  end
+  require Logger
 
   @impl true
   def server_info do
@@ -30,7 +28,8 @@ defmodule Upcase.Server do
   component(Upcase.Resources.Examples)
 
   @impl true
-  def init(:ok, frame) do
+  def init(client_info, frame) do
+    Logger.info("We had the client_info: #{inspect(client_info)}")
     schedule_hello()
     {:ok, assign(frame, counter: 0)}
   end

--- a/test/hermes/server/base_test.exs
+++ b/test/hermes/server/base_test.exs
@@ -17,7 +17,6 @@ defmodule Hermes.Server.BaseTest do
                Base.start_link(
                  module: StubServer,
                  name: :named_server,
-                 init_arg: :ok,
                  transport: [layer: StubTransport, name: transport]
                )
 
@@ -31,7 +30,6 @@ defmodule Hermes.Server.BaseTest do
                Base.start_link(
                  module: StubServer,
                  name: :named_server,
-                 init_arg: :ok,
                  transport: [layer: StubTransport, name: transport]
                )
 
@@ -99,7 +97,6 @@ defmodule Hermes.Server.BaseTest do
          [
            module: StubServer,
            name: :expiry_test_server,
-           init_arg: :ok,
            transport: [layer: StubTransport, name: transport],
            # 100ms for testing
            session_idle_timeout: 100
@@ -131,7 +128,6 @@ defmodule Hermes.Server.BaseTest do
            [
              module: StubServer,
              name: :reset_test_server,
-             init_arg: :ok,
              transport: [layer: StubTransport, name: transport],
              session_idle_timeout: 200
            ]}
@@ -169,7 +165,6 @@ defmodule Hermes.Server.BaseTest do
            [
              module: StubServer,
              name: :notification_reset_server,
-             init_arg: :ok,
              transport: [layer: StubTransport, name: transport],
              session_idle_timeout: 200
            ]}

--- a/test/hermes/server/component/tool_annotations_test.exs
+++ b/test/hermes/server/component/tool_annotations_test.exs
@@ -3,7 +3,6 @@ defmodule Hermes.Server.Component.ToolAnnotationsTest do
 
   alias Hermes.MCP.Message
   alias Hermes.Server.Component
-  alias Hermes.Server.Component.Tool
 
   defmodule ToolWithAnnotations do
     @moduledoc "A tool with annotations"
@@ -75,54 +74,9 @@ defmodule Hermes.Server.Component.ToolAnnotationsTest do
   end
 
   describe "tool annotations" do
-    test "tool with annotations in use macro" do
-      protocol = Tool.to_protocol(ToolWithAnnotations, nil, "2025-03-26")
-
-      assert protocol["name"] == "tool_with_annotations"
-      assert protocol["description"] == "A tool with annotations"
-      assert protocol["inputSchema"]["type"] == "object"
-
-      assert protocol["annotations"] == %{
-               "confidence" => 0.95,
-               "category" => "text-processing",
-               "tags" => ["nlp", "text", "analysis"]
-             }
-    end
-
-    test "tool without annotations" do
-      protocol = Tool.to_protocol(ToolWithoutAnnotations, nil, "2025-03-26")
-
-      assert protocol["name"] == "tool_without_annotations"
-      assert protocol["description"] == "A tool without annotations"
-      assert protocol["inputSchema"]["type"] == "object"
-      refute Map.has_key?(protocol, "annotations")
-    end
-
-    test "tool with custom annotations implementation" do
-      protocol = Tool.to_protocol(ToolWithCustomAnnotations, nil, "2025-03-26")
-
-      assert protocol["name"] == "tool_with_custom_annotations"
-      assert protocol["description"] == "A tool with custom annotations implementation"
-      assert protocol["inputSchema"]["type"] == "object"
-
-      assert protocol["annotations"] == %{
-               "version" => "2.0",
-               "experimental" => true,
-               "capabilities" => %{
-                 "streaming" => false,
-                 "batch" => true
-               }
-             }
-    end
-
     test "annotations callback is optional" do
-      # Verify that ToolWithAnnotations implements annotations
       assert function_exported?(ToolWithAnnotations, :annotations, 0)
-
-      # Verify that ToolWithoutAnnotations does not implement annotations
       refute function_exported?(ToolWithoutAnnotations, :annotations, 0)
-
-      # Verify that ToolWithCustomAnnotations implements annotations
       assert function_exported?(ToolWithCustomAnnotations, :annotations, 0)
     end
   end
@@ -177,14 +131,12 @@ defmodule Hermes.Server.Component.ToolAnnotationsTest do
     test "lists tools with and without annotations", %{server: server, session_id: session_id} do
       request = build_request("tools/list", %{})
       {:ok, response_string} = GenServer.call(server, {:request, request, session_id, %{}})
-
       {:ok, [response]} = Message.decode(response_string)
 
       assert response["result"]
       tools = response["result"]["tools"]
       assert length(tools) == 3
 
-      # Find each tool and verify its annotations
       tool_with_annotations = Enum.find(tools, &(&1["name"] == "tool_with_annotations"))
       assert tool_with_annotations["annotations"]["confidence"] == 0.95
       assert tool_with_annotations["annotations"]["category"] == "text-processing"
@@ -195,9 +147,9 @@ defmodule Hermes.Server.Component.ToolAnnotationsTest do
 
       tool_with_custom = Enum.find(tools, &(&1["name"] == "tool_with_custom_annotations"))
       assert tool_with_custom["annotations"]["version"] == "2.0"
-      assert tool_with_custom["annotations"]["experimental"] == true
-      assert tool_with_custom["annotations"]["capabilities"]["streaming"] == false
-      assert tool_with_custom["annotations"]["capabilities"]["batch"] == true
+      assert tool_with_custom["annotations"]["experimental"]
+      assert tool_with_custom["annotations"]["capabilities"]["batch"]
+      refute tool_with_custom["annotations"]["capabilities"]["streaming"]
     end
   end
 end

--- a/test/hermes/server/component/tool_annotations_test.exs
+++ b/test/hermes/server/component/tool_annotations_test.exs
@@ -158,7 +158,6 @@ defmodule Hermes.Server.Component.ToolAnnotationsTest do
       server_opts = [
         module: ServerWithAnnotatedTools,
         name: :test_server,
-        init_arg: :ok,
         registry: Hermes.Server.Registry,
         transport: [layer: StubTransport, name: transport]
       ]

--- a/test/hermes/server/transport/sse/plug_test.exs
+++ b/test/hermes/server/transport/sse/plug_test.exs
@@ -126,7 +126,6 @@ defmodule Hermes.Server.Transport.SSE.PlugTest do
           Base,
           module: StubServer,
           name: registry.server(StubServer),
-          init_arg: :ok,
           transport: [layer: StubTransport, name: stub_transport],
           registry: registry
         })

--- a/test/hermes/server/transport/streamable_http/plug_test.exs
+++ b/test/hermes/server/transport/streamable_http/plug_test.exs
@@ -115,7 +115,6 @@ defmodule Hermes.Server.Transport.StreamableHTTP.PlugTest do
           Hermes.Server.Base,
           module: StubServer,
           name: registry.server(StubServer),
-          init_arg: :ok,
           transport: [layer: StubTransport, name: stub_transport],
           registry: registry
         })
@@ -364,7 +363,6 @@ defmodule Hermes.Server.Transport.StreamableHTTP.PlugTest do
           Hermes.Server.Base,
           module: StubServer,
           name: registry.server(StubServer),
-          init_arg: :ok,
           transport: [layer: StubTransport, name: stub_transport],
           registry: registry
         })

--- a/test/support/mcp/setup.ex
+++ b/test/support/mcp/setup.ex
@@ -151,7 +151,6 @@ defmodule Hermes.MCP.Setup do
     server_opts = [
       module: server_module,
       name: server_name,
-      init_arg: :ok,
       registry: registry,
       transport: [
         layer: transport,
@@ -191,7 +190,6 @@ defmodule Hermes.MCP.Setup do
 
     opts = [
       module: server_module,
-      init_arg: :ok,
       name: name,
       transport: [layer: Transport.STDIO, name: transport_name]
     ]

--- a/test/support/stub_server.ex
+++ b/test/support/stub_server.ex
@@ -68,7 +68,7 @@ defmodule StubServer do
   def handle_request(%{"method" => "resources/" <> action, "params" => params}, frame) do
     case action do
       "list" -> {:reply, %{"resources" => @resources}, frame}
-      "read" -> handle_resource_read(params, frame)
+      "read" -> handle_read_resource(params, frame)
     end
   end
 
@@ -92,7 +92,7 @@ defmodule StubServer do
     {:error, Error.protocol(:invalid_request, %{message: "tool #{name} not found"}), frame}
   end
 
-  defp handle_resource_read(%{"uri" => uri}, frame) do
+  defp handle_read_resource(%{"uri" => uri}, frame) do
     Response.resource()
     |> Response.text("some teste config")
     |> Response.to_protocol(uri, "text/plain")

--- a/test/support/stub_server.ex
+++ b/test/support/stub_server.ex
@@ -46,15 +46,6 @@ defmodule StubServer do
     }
   ]
 
-  def start_link(opts) do
-    Hermes.Server.start_link(__MODULE__, :ok, opts)
-  end
-
-  @impl true
-  def init(:ok, frame) do
-    {:ok, frame}
-  end
-
   @impl true
   def handle_request(%{"method" => "ping"}, frame) do
     {:reply, %{}, frame}


### PR DESCRIPTION
## Problem

The current MCP server implementation requires components (tools, resources, prompts) to be defined as modules at compile-time,
limiting flexibility and making it difficult to dynamically register components based on runtime conditions.

## Solution

- Introduced runtime component registration through the Frame API (Frame.register_tool/3, Frame.register_resource/3,
Frame.register_prompt/3)
- Added new server callbacks (handle_tool_call/3, handle_resource_read/3, handle_prompt_get/3) for granular request handling
- Converted components from behaviors to structs with JSON.Encoder implementations
- Moved server initialization to MCP handshake phase instead of GenServer startup

## Rationale

This hybrid approach maintains backward compatibility with module-based components while enabling dynamic component
registration. It allows servers to conditionally expose functionality based on client capabilities, runtime configuration, or
other dynamic factors, making the framework more flexible for real-world MCP implementations.
