### PR TITLE
fix: loggin should respect the logger config

### DIFF
--- a/lib/hermes/client/base.ex
+++ b/lib/hermes/client/base.ex
@@ -27,6 +27,7 @@ defmodule Hermes.Client.Base do
   alias Hermes.Protocol
   alias Hermes.Telemetry
 
+  require Hermes.Logging
   require Hermes.MCP.Message
 
   @default_protocol_version Protocol.latest_version()

--- a/lib/hermes/client/base.ex
+++ b/lib/hermes/client/base.ex
@@ -13,13 +13,13 @@ defmodule Hermes.Client.Base do
   """
 
   use GenServer
+  use Hermes.Logging
 
   import Peri
 
   alias Hermes.Client.Operation
   alias Hermes.Client.Request
   alias Hermes.Client.State
-  alias Hermes.Logging
   alias Hermes.MCP.Error
   alias Hermes.MCP.ID
   alias Hermes.MCP.Message
@@ -27,7 +27,6 @@ defmodule Hermes.Client.Base do
   alias Hermes.Protocol
   alias Hermes.Telemetry
 
-  require Hermes.Logging
   require Hermes.MCP.Message
 
   @default_protocol_version Protocol.latest_version()

--- a/lib/hermes/http.ex
+++ b/lib/hermes/http.ex
@@ -1,7 +1,7 @@
 defmodule Hermes.HTTP do
   @moduledoc false
 
-  require Hermes.Logging
+  use Hermes.Logging
 
   @default_headers %{
     "content-type" => "application/json"

--- a/lib/hermes/http.ex
+++ b/lib/hermes/http.ex
@@ -1,7 +1,7 @@
 defmodule Hermes.HTTP do
   @moduledoc false
 
-  require Logger
+  require Hermes.Logging
 
   @default_headers %{
     "content-type" => "application/json"

--- a/lib/hermes/logging.ex
+++ b/lib/hermes/logging.ex
@@ -73,7 +73,7 @@ defmodule Hermes.Logging do
 
       Hermes.Logging.log(level, "MCP server event: #{unquote(event)}", metadata)
 
-      if unquote(details) do
+      if Hermes.Logging.should_log_details?(unquote(details)) do
         Hermes.Logging.log(
           level,
           "MCP event details: #{inspect(unquote(details))}",
@@ -98,7 +98,7 @@ defmodule Hermes.Logging do
 
       Hermes.Logging.log(level, "MCP client event: #{unquote(event)}", metadata)
 
-      if unquote(details) do
+      if Hermes.Logging.should_log_details?(unquote(details)) do
         Hermes.Logging.log(
           level,
           "MCP event details: #{inspect(unquote(details))}",
@@ -123,7 +123,7 @@ defmodule Hermes.Logging do
 
       Hermes.Logging.log(level, "MCP transport event: #{unquote(event)}", metadata)
 
-      if unquote(details) do
+      if Hermes.Logging.should_log_details?(unquote(details)) do
         Hermes.Logging.log(
           level,
           "MCP transport details: #{inspect(unquote(details))}",
@@ -191,6 +191,7 @@ defmodule Hermes.Logging do
   @doc false
   def should_log_details?(data) when is_binary(data), do: byte_size(data) < 500
   def should_log_details?(data) when is_map(data), do: map_size(data) < 10
+  def should_log_details?(nil), do: false
   def should_log_details?(_), do: true
 
   @doc false

--- a/lib/hermes/logging.ex
+++ b/lib/hermes/logging.ex
@@ -13,25 +13,38 @@ defmodule Hermes.Logging do
     * data - the message content
     * metadata - additional metadata to include with level option (:debug, :info, :warning, :error, etc.)
   """
-  def message(direction, type, id, data, metadata \\ []) do
-    summary = create_message_summary(type, id, data)
-    level = Keyword.get(metadata, :level, get_logging_level(:protocol_messages))
-    metadata = Keyword.delete(metadata, :level)
+  defmacro message(direction, type, id, data, metadata \\ []) do
+    quote do
+      level = Hermes.Logging.get_logging_level(:protocol_messages)
+      level = Keyword.get(unquote(metadata), :level, level)
+      metadata = Keyword.delete(unquote(metadata), :level)
 
-    log(level, "[MCP message] #{direction} #{type}: #{summary}", metadata)
+      summary =
+        Hermes.Logging.create_message_summary(
+          unquote(type),
+          unquote(id),
+          unquote(data)
+        )
 
-    if should_log_details?(data) do
-      log(
+      Hermes.Logging.log(
         level,
-        "[MCP message] #{direction} #{type} data: #{inspect(data)}",
+        "[MCP message] #{unquote(direction)} #{unquote(type)}: #{summary}",
         metadata
       )
-    else
-      log(
-        level,
-        "[MCP message] #{direction} #{type} data (truncated): #{truncate_data(data)}",
-        metadata
-      )
+
+      if Hermes.Logging.should_log_details?(unquote(data)) do
+        Hermes.Logging.log(
+          level,
+          "[MCP message] #{unquote(direction)} #{unquote(type)} data: #{inspect(unquote(data))}",
+          metadata
+        )
+      else
+        Hermes.Logging.log(
+          level,
+          "[MCP message] #{unquote(direction)} #{unquote(type)} data (truncated): #{Hermes.Logging.truncate_data(unquote(data))}",
+          metadata
+        )
+      end
     end
   end
 
@@ -42,14 +55,21 @@ defmodule Hermes.Logging do
     * metadata - Additional metadata including:
       * :level - The log level (:debug, :info, :warning, :error, etc.)
   """
-  def server_event(event, details, metadata \\ []) do
-    level = Keyword.get(metadata, :level, get_logging_level(:server_events))
-    metadata = Keyword.delete(metadata, :level)
+  defmacro server_event(event, details, metadata \\ []) do
+    quote do
+      level = Hermes.Logging.get_logging_level(:server_events)
+      level = Keyword.get(unquote(metadata), :level, level)
+      metadata = Keyword.delete(unquote(metadata), :level)
 
-    log(level, "MCP server event: #{event}", metadata)
+      Hermes.Logging.log(level, "MCP server event: #{unquote(event)}", metadata)
 
-    if details do
-      log(level, "MCP event details: #{inspect(details)}", metadata)
+      if unquote(details) do
+        Hermes.Logging.log(
+          level,
+          "MCP event details: #{inspect(unquote(details))}",
+          metadata
+        )
+      end
     end
   end
 
@@ -60,14 +80,21 @@ defmodule Hermes.Logging do
     * metadata - Additional metadata including:
       * :level - The log level (:debug, :info, :warning, :error, etc.)
   """
-  def client_event(event, details, metadata \\ []) do
-    level = Keyword.get(metadata, :level, get_logging_level(:client_events))
-    metadata = Keyword.delete(metadata, :level)
+  defmacro client_event(event, details, metadata \\ []) do
+    quote do
+      level = Hermes.Logging.get_logging_level(:client_events)
+      level = Keyword.get(unquote(metadata), :level, level)
+      metadata = Keyword.delete(unquote(metadata), :level)
 
-    log(level, "MCP client event: #{event}", metadata)
+      Hermes.Logging.log(level, "MCP client event: #{unquote(event)}", metadata)
 
-    if details do
-      log(level, "MCP event details: #{inspect(details)}", metadata)
+      if unquote(details) do
+        Hermes.Logging.log(
+          level,
+          "MCP event details: #{inspect(unquote(details))}",
+          metadata
+        )
+      end
     end
   end
 
@@ -78,20 +105,28 @@ defmodule Hermes.Logging do
     * metadata - Additional metadata including:
       * :level - The log level (:debug, :info, :warning, :error, etc.)
   """
-  def transport_event(event, details, metadata \\ []) do
-    level = Keyword.get(metadata, :level, get_logging_level(:transport_events))
-    metadata = Keyword.delete(metadata, :level)
+  defmacro transport_event(event, details, metadata \\ []) do
+    quote do
+      level = Hermes.Logging.get_logging_level(:transport_events)
+      level = Keyword.get(unquote(metadata), :level, level)
+      metadata = Keyword.delete(unquote(metadata), :level)
 
-    log(level, "MCP transport event: #{event}", metadata)
+      Hermes.Logging.log(level, "MCP transport event: #{unquote(event)}", metadata)
 
-    if details do
-      log(level, "MCP transport details: #{inspect(details)}", metadata)
+      if unquote(details) do
+        Hermes.Logging.log(
+          level,
+          "MCP transport details: #{inspect(unquote(details))}",
+          metadata
+        )
+      end
     end
   end
 
   # Private helpers
 
-  defp log(level, message, metadata) when is_atom(level) do
+  @doc false
+  def log(level, message, metadata) when is_atom(level) do
     if should_log?(level), do: log_by_level(level, message, metadata)
   end
 
@@ -101,19 +136,21 @@ defmodule Hermes.Logging do
     log? and Logger.compare_levels(config_level, level) != :lt
   end
 
-  defp get_logging_level(event_type) do
+  @doc false
+  def get_logging_level(event_type) do
     logging_config = Application.get_env(:hermes_mcp, :logging, [])
     Keyword.get(logging_config, event_type, :debug)
   end
 
   defp log_by_level(level, msg, metadata), do: apply(Logger, level, [msg, metadata])
 
-  defp create_message_summary("request", id, data) when is_map(data) do
+  @doc false
+  def create_message_summary("request", id, data) when is_map(data) do
     method = Map.get(data, "method", "unknown")
     "id=#{id || "none"} method=#{method}"
   end
 
-  defp create_message_summary("response", id, data) when is_map(data) do
+  def create_message_summary("response", id, data) when is_map(data) do
     result_summary =
       cond do
         Map.has_key?(data, "result") -> "success"
@@ -124,23 +161,25 @@ defmodule Hermes.Logging do
     "id=#{id || "none"} #{result_summary}"
   end
 
-  defp create_message_summary("notification", _id, data) when is_map(data) do
+  def create_message_summary("notification", _id, data) when is_map(data) do
     method = Map.get(data, "method", "unknown")
     "method=#{method}"
   end
 
-  defp create_message_summary(_type, id, _data) do
+  def create_message_summary(_type, id, _data) do
     "id=#{id || "none"}"
   end
 
-  defp should_log_details?(data) when is_binary(data), do: byte_size(data) < 500
-  defp should_log_details?(data) when is_map(data), do: map_size(data) < 10
-  defp should_log_details?(_), do: true
+  @doc false
+  def should_log_details?(data) when is_binary(data), do: byte_size(data) < 500
+  def should_log_details?(data) when is_map(data), do: map_size(data) < 10
+  def should_log_details?(_), do: true
 
-  defp truncate_data(data) when is_binary(data),
+  @doc false
+  def truncate_data(data) when is_binary(data),
     do: "#{String.slice(data, 0, 100)}..."
 
-  defp truncate_data(data) when is_map(data) do
+  def truncate_data(data) when is_map(data) do
     important_keys =
       case data do
         %{"id" => _, "method" => _} -> ["id", "method"]
@@ -156,5 +195,5 @@ defmodule Hermes.Logging do
     |> Kernel.<>("...")
   end
 
-  defp truncate_data(data), do: inspect(data, limit: 5)
+  def truncate_data(data), do: inspect(data, limit: 5)
 end

--- a/lib/hermes/logging.ex
+++ b/lib/hermes/logging.ex
@@ -3,6 +3,16 @@ defmodule Hermes.Logging do
 
   require Logger
 
+  @doc false
+  defmacro __using__(_) do
+    quote do
+      alias Hermes.Logging
+
+      require Hermes.Logging
+      require Logger
+    end
+  end
+
   @doc """
   Log protocol messages with automatic formatting and context.
 
@@ -142,7 +152,15 @@ defmodule Hermes.Logging do
     Keyword.get(logging_config, event_type, :debug)
   end
 
-  defp log_by_level(level, msg, metadata), do: apply(Logger, level, [msg, metadata])
+  defp log_by_level(:debug, msg, metadata), do: Logger.debug(msg, metadata)
+  defp log_by_level(:info, msg, metadata), do: Logger.info(msg, metadata)
+  defp log_by_level(:notice, msg, metadata), do: Logger.notice(msg, metadata)
+  defp log_by_level(:warning, msg, metadata), do: Logger.warning(msg, metadata)
+  defp log_by_level(:error, msg, metadata), do: Logger.error(msg, metadata)
+  defp log_by_level(:critical, msg, metadata), do: Logger.critical(msg, metadata)
+  defp log_by_level(:alert, msg, metadata), do: Logger.alert(msg, metadata)
+  defp log_by_level(:emergency, msg, metadata), do: Logger.emergency(msg, metadata)
+  defp log_by_level(_, msg, metadata), do: Logger.info(msg, metadata)
 
   @doc false
   def create_message_summary("request", id, data) when is_map(data) do

--- a/lib/hermes/server/base.ex
+++ b/lib/hermes/server/base.ex
@@ -2,10 +2,10 @@ defmodule Hermes.Server.Base do
   @moduledoc false
 
   use GenServer
+  use Hermes.Logging
 
   import Peri
 
-  alias Hermes.Logging
   alias Hermes.MCP.Error
   alias Hermes.MCP.Message
   alias Hermes.Protocol
@@ -15,7 +15,6 @@ defmodule Hermes.Server.Base do
   alias Hermes.Server.Session.Supervisor, as: SessionSupervisor
   alias Hermes.Telemetry
 
-  require Hermes.Logging
   require Message
   require Server
   require Session

--- a/lib/hermes/server/base.ex
+++ b/lib/hermes/server/base.ex
@@ -15,6 +15,7 @@ defmodule Hermes.Server.Base do
   alias Hermes.Server.Session.Supervisor, as: SessionSupervisor
   alias Hermes.Telemetry
 
+  require Hermes.Logging
   require Message
   require Server
   require Session

--- a/lib/hermes/server/transport/sse.ex
+++ b/lib/hermes/server/transport/sse.ex
@@ -54,15 +54,14 @@ defmodule Hermes.Server.Transport.SSE do
   @behaviour Hermes.Transport.Behaviour
 
   use GenServer
+  use Hermes.Logging
 
   import Peri
 
-  alias Hermes.Logging
   alias Hermes.MCP.Message
   alias Hermes.Telemetry
   alias Hermes.Transport.Behaviour, as: Transport
 
-  require Hermes.Logging
   require Message
 
   @type t :: GenServer.server()

--- a/lib/hermes/server/transport/sse.ex
+++ b/lib/hermes/server/transport/sse.ex
@@ -62,6 +62,7 @@ defmodule Hermes.Server.Transport.SSE do
   alias Hermes.Telemetry
   alias Hermes.Transport.Behaviour, as: Transport
 
+  require Hermes.Logging
   require Message
 
   @type t :: GenServer.server()

--- a/lib/hermes/server/transport/sse/plug.ex
+++ b/lib/hermes/server/transport/sse/plug.ex
@@ -81,6 +81,7 @@ if Code.ensure_loaded?(Plug) do
     alias Hermes.SSE.Streaming
     alias Plug.Conn.Unfetched
 
+    require Hermes.Logging
     require Message
 
     @default_timeout 30_000

--- a/lib/hermes/server/transport/sse/plug.ex
+++ b/lib/hermes/server/transport/sse/plug.ex
@@ -71,9 +71,10 @@ if Code.ensure_loaded?(Plug) do
 
     @behaviour Plug
 
+    use Hermes.Logging
+
     import Plug.Conn
 
-    alias Hermes.Logging
     alias Hermes.MCP.Error
     alias Hermes.MCP.ID
     alias Hermes.MCP.Message
@@ -81,7 +82,6 @@ if Code.ensure_loaded?(Plug) do
     alias Hermes.SSE.Streaming
     alias Plug.Conn.Unfetched
 
-    require Hermes.Logging
     require Message
 
     @default_timeout 30_000

--- a/lib/hermes/server/transport/stdio.ex
+++ b/lib/hermes/server/transport/stdio.ex
@@ -18,6 +18,7 @@ defmodule Hermes.Server.Transport.STDIO do
   alias Hermes.Telemetry
   alias Hermes.Transport.Behaviour, as: Transport
 
+  require Hermes.Logging
   require Message
 
   @type t :: GenServer.server()

--- a/lib/hermes/server/transport/stdio.ex
+++ b/lib/hermes/server/transport/stdio.ex
@@ -9,16 +9,15 @@ defmodule Hermes.Server.Transport.STDIO do
   @behaviour Hermes.Transport.Behaviour
 
   use GenServer
+  use Hermes.Logging
 
   import Peri
 
-  alias Hermes.Logging
   alias Hermes.MCP.Error
   alias Hermes.MCP.Message
   alias Hermes.Telemetry
   alias Hermes.Transport.Behaviour, as: Transport
 
-  require Hermes.Logging
   require Message
 
   @type t :: GenServer.server()

--- a/lib/hermes/server/transport/streamable_http.ex
+++ b/lib/hermes/server/transport/streamable_http.ex
@@ -56,6 +56,7 @@ defmodule Hermes.Server.Transport.StreamableHTTP do
   alias Hermes.Telemetry
   alias Hermes.Transport.Behaviour, as: Transport
 
+  require Hermes.Logging
   require Message
 
   @type t :: GenServer.server()

--- a/lib/hermes/server/transport/streamable_http.ex
+++ b/lib/hermes/server/transport/streamable_http.ex
@@ -47,16 +47,15 @@ defmodule Hermes.Server.Transport.StreamableHTTP do
   @behaviour Hermes.Transport.Behaviour
 
   use GenServer
+  use Hermes.Logging
 
   import Peri
 
-  alias Hermes.Logging
   alias Hermes.MCP.Error
   alias Hermes.MCP.Message
   alias Hermes.Telemetry
   alias Hermes.Transport.Behaviour, as: Transport
 
-  require Hermes.Logging
   require Message
 
   @type t :: GenServer.server()

--- a/lib/hermes/server/transport/streamable_http/plug.ex
+++ b/lib/hermes/server/transport/streamable_http/plug.ex
@@ -56,9 +56,10 @@ if Code.ensure_loaded?(Plug) do
 
     @behaviour Plug
 
+    use Hermes.Logging
+
     import Plug.Conn
 
-    alias Hermes.Logging
     alias Hermes.MCP.Error
     alias Hermes.MCP.ID
     alias Hermes.MCP.Message
@@ -66,7 +67,6 @@ if Code.ensure_loaded?(Plug) do
     alias Hermes.SSE.Streaming
     alias Plug.Conn.Unfetched
 
-    require Hermes.Logging
     require Message
 
     @default_session_header "mcp-session-id"

--- a/lib/hermes/server/transport/streamable_http/plug.ex
+++ b/lib/hermes/server/transport/streamable_http/plug.ex
@@ -66,6 +66,7 @@ if Code.ensure_loaded?(Plug) do
     alias Hermes.SSE.Streaming
     alias Plug.Conn.Unfetched
 
+    require Hermes.Logging
     require Message
 
     @default_session_header "mcp-session-id"

--- a/lib/hermes/sse.ex
+++ b/lib/hermes/sse.ex
@@ -3,7 +3,7 @@ defmodule Hermes.SSE do
 
   alias Hermes.SSE.Parser
 
-  require Logger
+  require Hermes.Logging
 
   @connection_headers %{
     "accept" => "text/event-stream",

--- a/lib/hermes/sse.ex
+++ b/lib/hermes/sse.ex
@@ -3,7 +3,7 @@ defmodule Hermes.SSE do
 
   alias Hermes.SSE.Parser
 
-  require Hermes.Logging
+  use Hermes.Logging
 
   @connection_headers %{
     "accept" => "text/event-stream",

--- a/lib/hermes/sse.ex
+++ b/lib/hermes/sse.ex
@@ -1,9 +1,9 @@
 defmodule Hermes.SSE do
   @moduledoc false
 
-  alias Hermes.SSE.Parser
-
   use Hermes.Logging
+
+  alias Hermes.SSE.Parser
 
   @connection_headers %{
     "accept" => "text/event-stream",

--- a/lib/hermes/sse/streaming.ex
+++ b/lib/hermes/sse/streaming.ex
@@ -2,10 +2,9 @@ if Code.ensure_loaded?(Plug) do
   defmodule Hermes.SSE.Streaming do
     @moduledoc false
 
-    alias Hermes.Logging
-    alias Hermes.SSE.Event
+    use Hermes.Logging
 
-    require Hermes.Logging
+    alias Hermes.SSE.Event
 
     @type conn :: Plug.Conn.t()
     @type transport :: GenServer.server()

--- a/lib/hermes/sse/streaming.ex
+++ b/lib/hermes/sse/streaming.ex
@@ -5,6 +5,8 @@ if Code.ensure_loaded?(Plug) do
     alias Hermes.Logging
     alias Hermes.SSE.Event
 
+    require Hermes.Logging
+
     @type conn :: Plug.Conn.t()
     @type transport :: GenServer.server()
     @type session_id :: String.t()

--- a/lib/hermes/transport/sse.ex
+++ b/lib/hermes/transport/sse.ex
@@ -12,17 +12,15 @@ defmodule Hermes.Transport.SSE do
   @behaviour Hermes.Transport.Behaviour
 
   use GenServer
+  use Hermes.Logging
 
   import Peri
 
   alias Hermes.HTTP
-  alias Hermes.Logging
   alias Hermes.SSE
   alias Hermes.SSE.Event
   alias Hermes.Telemetry
   alias Hermes.Transport.Behaviour, as: Transport
-
-  require Hermes.Logging
 
   @type t :: GenServer.server()
 

--- a/lib/hermes/transport/sse.ex
+++ b/lib/hermes/transport/sse.ex
@@ -22,6 +22,8 @@ defmodule Hermes.Transport.SSE do
   alias Hermes.Telemetry
   alias Hermes.Transport.Behaviour, as: Transport
 
+  require Hermes.Logging
+
   @type t :: GenServer.server()
 
   @typedoc """

--- a/lib/hermes/transport/stdio.ex
+++ b/lib/hermes/transport/stdio.ex
@@ -18,7 +18,7 @@ defmodule Hermes.Transport.STDIO do
   alias Hermes.Telemetry
   alias Hermes.Transport.Behaviour, as: Transport
 
-  require Logger
+  require Hermes.Logging
 
   @type t :: GenServer.server()
 

--- a/lib/hermes/transport/stdio.ex
+++ b/lib/hermes/transport/stdio.ex
@@ -11,14 +11,12 @@ defmodule Hermes.Transport.STDIO do
   @behaviour Hermes.Transport.Behaviour
 
   use GenServer
+  use Hermes.Logging
 
   import Peri
 
-  alias Hermes.Logging
   alias Hermes.Telemetry
   alias Hermes.Transport.Behaviour, as: Transport
-
-  require Hermes.Logging
 
   @type t :: GenServer.server()
 

--- a/lib/hermes/transport/streamable_http.ex
+++ b/lib/hermes/transport/streamable_http.ex
@@ -52,6 +52,8 @@ defmodule Hermes.Transport.StreamableHTTP do
   alias Hermes.Telemetry
   alias Hermes.Transport.Behaviour, as: Transport
 
+  require Hermes.Logging
+
   @type t :: GenServer.server()
   @type params_t :: Enumerable.t(option)
 

--- a/lib/hermes/transport/streamable_http.ex
+++ b/lib/hermes/transport/streamable_http.ex
@@ -42,17 +42,15 @@ defmodule Hermes.Transport.StreamableHTTP do
   @behaviour Hermes.Transport.Behaviour
 
   use GenServer
+  use Hermes.Logging
 
   import Peri
 
   alias Hermes.HTTP
-  alias Hermes.Logging
   alias Hermes.SSE
   alias Hermes.SSE.Event
   alias Hermes.Telemetry
   alias Hermes.Transport.Behaviour, as: Transport
-
-  require Hermes.Logging
 
   @type t :: GenServer.server()
   @type params_t :: Enumerable.t(option)

--- a/lib/hermes/transport/websocket.ex
+++ b/lib/hermes/transport/websocket.ex
@@ -13,14 +13,12 @@ if Code.ensure_loaded?(:gun) do
     @behaviour Hermes.Transport.Behaviour
 
     use GenServer
+    use Hermes.Logging
 
     import Peri
 
-    alias Hermes.Logging
     alias Hermes.Telemetry
     alias Hermes.Transport.Behaviour, as: Transport
-
-    require Hermes.Logging
 
     @type t :: GenServer.server()
 

--- a/lib/hermes/transport/websocket.ex
+++ b/lib/hermes/transport/websocket.ex
@@ -20,6 +20,8 @@ if Code.ensure_loaded?(:gun) do
     alias Hermes.Telemetry
     alias Hermes.Transport.Behaviour, as: Transport
 
+    require Hermes.Logging
+
     @type t :: GenServer.server()
 
     @typedoc """

--- a/pages/logging.md
+++ b/pages/logging.md
@@ -1,68 +1,119 @@
 # Logging
 
-Hermes MCP supports server-to-client logging as specified in the [MCP protocol](https://spec.modelcontextprotocol.io/specification/2024-11-05/server/utilities/logging/). This allows servers to send structured log messages to clients for debugging and operational visibility.
+How does Hermes MCP handle the logging capabilities defined in the MCP protocol? Let's explore both the MCP logging features and how to configure Hermes's own internal logging.
 
-## Overview
+## MCP Logging Capability
 
-The logging mechanism follows the standard syslog severity levels and provides a way for servers to emit structured log messages. Clients can control the verbosity by setting minimum log levels, and register callbacks to handle log messages for custom processing.
+When building MCP clients, you'll often need to receive and process log messages from servers. How might you handle these structured messages in your Elixir application?
 
-## Setting Log Level
-
-Clients can specify the minimum log level they want to receive from servers:
+### Controlling Server Verbosity
 
 ```elixir
-# Configure the client to receive logs at "info" level or higher
 {:ok, _} = MyApp.MCPClient.set_log_level("info")
 ```
 
-Available log levels, in order of increasing severity:
-- `"debug"` - Detailed information for debugging
-- `"info"` - General information messages
-- `"notice"` - Normal but significant events
-- `"warning"` - Warning conditions
-- `"error"` - Error conditions
-- `"critical"` - Critical conditions
-- `"alert"` - Action must be taken immediately
-- `"emergency"` - System is unusable
+What happens behind the scenes? This sends a `logging/setLevel` request to the server, telling it to only send logs at "info" level or higher. The server will respect this preference when deciding which notifications to send your way.
 
-Setting a level will result in receiving all messages at that level and above (more severe).
+### Processing Incoming Logs
 
-## Receiving Log Messages
-
-### Registering Callbacks
-
-You can register a callback function to process log messages as they are received:
+Ever wondered how to handle those log notifications when they arrive? You have two approaches:
 
 ```elixir
-# Register a callback to handle incoming log messages
+# Register a custom handler
 MyApp.MCPClient.register_log_callback(fn level, data, logger ->
-  IO.puts("[#{level}] #{if logger, do: "[#{logger}] ", else: ""}#{inspect(data)}")
+  # Send to your monitoring service?
+  # Transform the format?
+  # Filter by logger name?
 end)
+
+# When done, clean up
+MyApp.MCPClient.unregister_log_callback()
 ```
 
-The callback function receives:
-- `level` - The log level (debug, info, notice, etc.)
-- `data` - The log data (any JSON-serializable value)
-- `logger` - Optional string identifying the logger source
+What's happening by default though? Hermes automatically forwards all MCP log messages to Elixir's Logger, mapping the levels appropriately. This means your existing log infrastructure just works - no additional setup required.
 
-### Unregistering Callbacks
+## Configuring Hermes Library Logs
 
-When you no longer need to process log messages, unregister the callback:
+Now, what about the logs that Hermes itself generates? How do you control the verbosity of the library's internal logging?
+
+### Fine-Grained Control
 
 ```elixir
-# Unregister a previously registered callback
-MyApp.MCPClient.unregister_log_callback()
-# :ok
+config :hermes_mcp, :logging,
+  client_events: :info,
+  server_events: :debug,
+  transport_events: :warning,
+  protocol_messages: :debug
 ```
 
-## Integrating with Elixir's Logger
+What do these categories mean for your debugging experience?
+- `client_events`: Client lifecycle and operations
+- `server_events`: Server request handling and responses  
+- `transport_events`: Connection and transport layer activity
+- `protocol_messages`: Raw MCP message exchanges
 
-By default, Hermes MCP automatically logs received messages to `Logger` app, mapping MCP log levels to their Elixir equivalents:
+### Global Toggle
 
-- `"debug"` → `Logger.debug/1`
-- `"info"`, `"notice"` → `Logger.info/1`
-- `"warning"` → `Logger.warning/1`
-- `"error"`, `"critical"`, `"alert"`, `"emergency"` → `Logger.error/1`
+Need to silence Hermes completely? Perhaps for performance testing or production deployments?
 
-This provides seamless integration with your existing logging setup, respecting the logger level you
-define con your config.
+```elixir
+config :hermes_mcp, log: false
+```
+
+This disables all library-emitted logs, regardless of individual category settings.
+
+## MCP Server Logging
+
+What if you're building an MCP server? How do you send logs to connected clients? Let's explore the server-side capabilities.
+
+### Declaring Logging Support
+
+```elixir
+defmodule MyServer do
+  use Hermes.Server,
+    name: "my-server",
+    version: "1.0.0",
+    capabilities: [:logging]  # Enable logging capability
+end
+```
+
+What does this capability tell clients? It signals that your server can receive `logging/setLevel` requests and will respect the client's verbosity preferences when sending log notifications.
+
+### Sending Log Messages
+
+How do you actually send logs from your server to clients? You have a straightforward API:
+
+```elixir
+# From within your server callbacks
+send_log_message(server, "info", "Processing started", "worker")
+
+# Or without a logger name
+send_log_message(server, "error", "Connection failed")
+```
+
+What happens when you send these? They become `notifications/message` events that clients process according to their configured handlers. The client's minimum log level (set via `set_log_level/1`) filters what they receive.
+
+### Progress Notifications
+
+Need to report progress on long-running operations? How might this improve user experience?
+
+```elixir
+# Start an operation with progress tracking
+send_progress(server, "import-123", 0, 100, "Starting import...")
+
+# Update as you go
+send_progress(server, "import-123", 45, 100, "Processing records...")
+
+# Complete
+send_progress(server, "import-123", 100, 100, "Import complete!")
+```
+
+## Practical Considerations
+
+How might you configure logging for different environments? Consider starting with `:debug` everywhere during development, then adjusting based on what you learn:
+
+- Keep `protocol_messages` at `:debug` unless debugging protocol issues
+- Set `transport_events` to `:warning` once your transport is stable
+- Use `:info` for client and server events in production
+
+What patterns emerge from your logs? Which categories provide the most value for your use case?

--- a/test/hermes/logging_test.exs
+++ b/test/hermes/logging_test.exs
@@ -1,9 +1,8 @@
 defmodule Hermes.LoggingTest do
   use ExUnit.Case
+  use Hermes.Logging
 
   import ExUnit.CaptureLog
-
-  alias Hermes.Logging
 
   @moduletag capture_log: true
 

--- a/test/hermes/logging_test.exs
+++ b/test/hermes/logging_test.exs
@@ -1,5 +1,5 @@
 defmodule Hermes.LoggingTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   use Hermes.Logging
 
   import ExUnit.CaptureLog

--- a/test/hermes/logging_test.exs
+++ b/test/hermes/logging_test.exs
@@ -7,7 +7,6 @@ defmodule Hermes.LoggingTest do
   @moduletag capture_log: true
 
   setup do
-    # Store original config to restore after each test
     original_log_config = Application.get_env(:hermes_mcp, :log)
     original_logging_config = Application.get_env(:hermes_mcp, :logging)
 
@@ -30,6 +29,7 @@ defmodule Hermes.LoggingTest do
 
   describe "configurable default log levels" do
     test "uses configured level for client events" do
+      Application.put_env(:logger, :level, :warning)
       Application.put_env(:hermes_mcp, :logging, client_events: :warning)
 
       log =
@@ -42,6 +42,7 @@ defmodule Hermes.LoggingTest do
     end
 
     test "uses configured level for server events" do
+      Application.put_env(:logger, :level, :error)
       Application.put_env(:hermes_mcp, :logging, server_events: :error)
 
       log =
@@ -54,6 +55,7 @@ defmodule Hermes.LoggingTest do
     end
 
     test "uses configured level for transport events" do
+      Application.put_env(:logger, :level, :info)
       Application.put_env(:hermes_mcp, :logging, transport_events: :info)
 
       log =
@@ -66,6 +68,7 @@ defmodule Hermes.LoggingTest do
     end
 
     test "uses configured level for protocol messages" do
+      Application.put_env(:logger, :level, :warning)
       Application.put_env(:hermes_mcp, :logging, protocol_messages: :warning)
 
       log =
@@ -97,6 +100,7 @@ defmodule Hermes.LoggingTest do
 
   describe "application config override behavior" do
     test "respects partial configuration" do
+      Application.put_env(:logger, :level, :error)
       Application.put_env(:hermes_mcp, :logging, client_events: :error)
 
       log =
@@ -161,6 +165,7 @@ defmodule Hermes.LoggingTest do
 
   describe "metadata level override behavior" do
     test "metadata level overrides default for client events" do
+      Application.put_env(:logger, :level, :error)
       Application.put_env(:hermes_mcp, :logging, client_events: :debug)
 
       log =
@@ -172,6 +177,7 @@ defmodule Hermes.LoggingTest do
     end
 
     test "metadata level overrides default for server events" do
+      Application.put_env(:logger, :level, :warning)
       Application.put_env(:hermes_mcp, :logging, server_events: :debug)
 
       log =
@@ -194,6 +200,7 @@ defmodule Hermes.LoggingTest do
     end
 
     test "metadata level overrides default for protocol messages" do
+      Application.put_env(:logger, :level, :error)
       Application.put_env(:hermes_mcp, :logging, protocol_messages: :debug)
 
       log =
@@ -379,13 +386,13 @@ defmodule Hermes.LoggingTest do
       assert log =~ "[info] MCP client event: test"
     end
 
-    test "maps notice to Logger.info" do
+    test "maps notice to Logger.notice" do
       log =
-        capture_log([level: :info], fn ->
+        capture_log([level: :notice], fn ->
           Logging.client_event("test", nil, level: :notice)
         end)
 
-      assert log =~ "[info] MCP client event: test"
+      assert log =~ "[notice] MCP client event: test"
     end
 
     test "maps warning to Logger.warning" do
@@ -398,6 +405,8 @@ defmodule Hermes.LoggingTest do
     end
 
     test "maps error to Logger.error" do
+      Application.put_env(:logger, :level, :error)
+
       log =
         capture_log([level: :error], fn ->
           Logging.client_event("test", nil, level: :error)
@@ -406,40 +415,37 @@ defmodule Hermes.LoggingTest do
       assert log =~ "[error] MCP client event: test"
     end
 
-    test "maps critical to Logger.error" do
+    test "maps critical to Logger.critical" do
+      Application.put_env(:logger, :level, :critical)
+
       log =
-        capture_log([level: :error], fn ->
+        capture_log([level: :critical], fn ->
           Logging.client_event("test", nil, level: :critical)
         end)
 
-      assert log =~ "[error] MCP client event: test"
+      assert log =~ "[critical] MCP client event: test"
     end
 
-    test "maps alert to Logger.error" do
+    test "maps alert to Logger.alert" do
+      Application.put_env(:logger, :level, :alert)
+
       log =
-        capture_log([level: :error], fn ->
+        capture_log([level: :alert], fn ->
           Logging.client_event("test", nil, level: :alert)
         end)
 
-      assert log =~ "[error] MCP client event: test"
+      assert log =~ "[alert] MCP client event: test"
     end
 
-    test "maps emergency to Logger.error" do
+    test "maps emergency to Logger.emergency" do
+      Application.put_env(:logger, :level, :emergency)
+
       log =
-        capture_log([level: :error], fn ->
+        capture_log([level: :emergency], fn ->
           Logging.client_event("test", nil, level: :emergency)
         end)
 
-      assert log =~ "[error] MCP client event: test"
-    end
-
-    test "maps unknown levels to Logger.info" do
-      log =
-        capture_log([level: :info], fn ->
-          Logging.client_event("test", nil, level: :unknown_level)
-        end)
-
-      assert log =~ "[info] MCP client event: test"
+      assert log =~ "[emergency] MCP client event: test"
     end
   end
 


### PR DESCRIPTION
## Problem

  `Hermes.Logging` functions were appearing as the log source instead of the actual caller module/function. `Logger` metadata showed incorrect source location.

##  Solution

  Converted logging functions to macros to capture caller metadata via Logger's built-in `__CALLER__` mechanism. Fixed level comparison logic and test expectations.

##  Rationale

  Macros execute in the caller's context, allowing `Logger` to automatically inject correct file/line/module metadata. This approach leverages Elixir's existing infrastructure rather than manually tracking metadata.