### PR TITLE
fix: interactive http tasks should accept custom headers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,4 +182,4 @@ jobs:
         run: mix clean
 
       - name: Run tests
-        run: mix test
+        run: mix test --trace --warnings-as-errors

--- a/lib/mix/tasks/sse.interactive.ex
+++ b/lib/mix/tasks/sse.interactive.ex
@@ -121,8 +121,6 @@ defmodule Mix.Tasks.Hermes.Sse.Interactive do
     |> Map.new()
   end
 
-  defp parse_headers(nil), do: %{}
-
   defp parse_header(header_string) do
     case String.split(header_string, ":", parts: 2) do
       [key, value] ->

--- a/lib/mix/tasks/sse.interactive.ex
+++ b/lib/mix/tasks/sse.interactive.ex
@@ -9,6 +9,13 @@ defmodule Mix.Tasks.Hermes.Sse.Interactive do
   * `--base-url` - Base URL for the SSE server (default: http://localhost:8000)
   * `--base-path` - Base path to append to the base URL
   * `--sse-path` - Specific SSE endpoint path
+  * `--header` - Add a header to requests (can be specified multiple times)
+
+  ## Examples
+
+      mix hermes.sse.interactive --base-url http://localhost:8000
+      mix hermes.sse.interactive --header "Authorization: Bearer token123"
+      mix hermes.sse.interactive --header "X-API-Key: secret" --header "X-Custom: value"
   """
 
   use Mix.Task
@@ -21,6 +28,7 @@ defmodule Mix.Tasks.Hermes.Sse.Interactive do
     base_url: :string,
     base_path: :string,
     sse_path: :string,
+    header: :keep,
     verbose: :count
   ]
 
@@ -42,6 +50,7 @@ defmodule Mix.Tasks.Hermes.Sse.Interactive do
     base_url = parsed[:base_url] || "http://localhost:8000"
     base_path = parsed[:base_path] || "/"
     sse_path = parsed[:sse_path] || "/sse"
+    headers = parse_headers(Keyword.get_values(parsed, :header))
 
     if base_url == "" do
       IO.puts(
@@ -70,7 +79,8 @@ defmodule Mix.Tasks.Hermes.Sse.Interactive do
           base_url: base_url,
           base_path: base_path,
           sse_path: sse_path
-        ]
+        ],
+        headers: headers
       ],
       client_opts: [
         name: :sse_test,
@@ -102,5 +112,28 @@ defmodule Mix.Tasks.Hermes.Sse.Interactive do
     metadata = Logger.metadata()
     Logger.configure(level: log_level)
     Logger.metadata(metadata)
+  end
+
+  defp parse_headers(header_list) when is_list(header_list) do
+    header_list
+    |> Enum.map(&parse_header/1)
+    |> Enum.reject(&is_nil/1)
+    |> Map.new()
+  end
+
+  defp parse_headers(nil), do: %{}
+
+  defp parse_header(header_string) do
+    case String.split(header_string, ":", parts: 2) do
+      [key, value] ->
+        {String.trim(key), String.trim(value)}
+
+      _ ->
+        IO.puts(
+          "#{UI.colors().warning}Warning: Invalid header format '#{header_string}'. Expected 'Header-Name: value'#{UI.colors().reset}"
+        )
+
+        nil
+    end
   end
 end

--- a/lib/mix/tasks/streamable_http.interactive.ex
+++ b/lib/mix/tasks/streamable_http.interactive.ex
@@ -107,8 +107,6 @@ defmodule Mix.Tasks.Hermes.StreamableHttp.Interactive do
     |> Map.new()
   end
 
-  defp parse_headers(nil), do: %{}
-
   defp parse_header(header_string) do
     case String.split(header_string, ":", parts: 2) do
       [key, value] ->

--- a/lib/mix/tasks/streamable_http.interactive.ex
+++ b/lib/mix/tasks/streamable_http.interactive.ex
@@ -8,6 +8,13 @@ defmodule Mix.Tasks.Hermes.StreamableHttp.Interactive do
 
   * `--base-url` - Base URL for the MCP server (default: http://localhost:8000)
   * `--mcp-path` - MCP endpoint path (default: /mcp)
+  * `--header` - Add a header to requests (can be specified multiple times)
+
+  ## Examples
+
+      mix hermes.streamable_http.interactive --base-url http://localhost:8000
+      mix hermes.streamable_http.interactive --header "Authorization: Bearer token123"
+      mix hermes.streamable_http.interactive --header "X-API-Key: secret" --header "X-Custom: value"
   """
 
   use Mix.Task
@@ -19,6 +26,7 @@ defmodule Mix.Tasks.Hermes.StreamableHttp.Interactive do
   @switches [
     base_url: :string,
     mcp_path: :string,
+    header: :keep,
     verbose: :count
   ]
 
@@ -39,6 +47,7 @@ defmodule Mix.Tasks.Hermes.StreamableHttp.Interactive do
     base_url = parsed[:base_url] || "http://localhost:8000"
     mcp_path = parsed[:mcp_path] || "/mcp"
     server_url = Path.join(base_url, mcp_path)
+    headers = parse_headers(Keyword.get_values(parsed, :header))
 
     header = UI.header("HERMES MCP STREAMABLE HTTP INTERACTIVE")
     IO.puts(header)
@@ -53,7 +62,8 @@ defmodule Mix.Tasks.Hermes.StreamableHttp.Interactive do
         name: StreamableHTTP,
         client: :streamable_http_test,
         base_url: base_url,
-        mcp_path: mcp_path
+        mcp_path: mcp_path,
+        headers: headers
       ],
       client_opts: [
         name: :streamable_http_test,
@@ -88,5 +98,28 @@ defmodule Mix.Tasks.Hermes.StreamableHttp.Interactive do
     metadata = Logger.metadata()
     Logger.configure(level: log_level)
     Logger.metadata(metadata)
+  end
+
+  defp parse_headers(header_list) when is_list(header_list) do
+    header_list
+    |> Enum.map(&parse_header/1)
+    |> Enum.reject(&is_nil/1)
+    |> Map.new()
+  end
+
+  defp parse_headers(nil), do: %{}
+
+  defp parse_header(header_string) do
+    case String.split(header_string, ":", parts: 2) do
+      [key, value] ->
+        {String.trim(key), String.trim(value)}
+
+      _ ->
+        IO.puts(
+          "#{UI.colors().warning}Warning: Invalid header format '#{header_string}'. Expected 'Header-Name: value'#{UI.colors().reset}"
+        )
+
+        nil
+    end
   end
 end


### PR DESCRIPTION
This pull request introduces support for custom headers in two Mix tasks (`hermes.sse.interactive` and `hermes.streamable_http.interactive`). The changes allow users to specify multiple headers for HTTP requests, improving flexibility and configurability. Key updates include the addition of a `--header` option, parsing logic for headers, and integration of headers into the request configuration.

### Add support for custom headers in Mix tasks:

#### `hermes.sse.interactive` updates:
* Added a `--header` option to allow users to specify custom headers for SSE requests, with examples provided in the documentation.
* Updated the `@switches` definition to include the `:header` option with the `:keep` modifier, enabling multiple values.
* Integrated a `parse_headers` function to process the `--header` values into a map of header key-value pairs.
* Modified the configuration setup to include parsed headers in the request options. [[1]](diffhunk://#diff-44c85059c08ec64f8a8319ba5d71df47925a28fc1abb33194c69760917ce7d6dR53) [[2]](diffhunk://#diff-44c85059c08ec64f8a8319ba5d71df47925a28fc1abb33194c69760917ce7d6dL73-R83)

#### `hermes.streamable_http.interactive` updates:
* Added a `--header` option to allow users to specify custom headers for MCP requests, with examples provided in the documentation.
* Updated the `@switches` definition to include the `:header` option with the `:keep` modifier, enabling multiple values.
* Integrated a `parse_headers` function to process the `--header` values into a map of header key-value pairs.
* Modified the configuration setup to include parsed headers in the request options. [[1]](diffhunk://#diff-3027336169662eef4888f5ec50e4b5184f7aca90993e0a2b9d733d41d6bebcb8R50) [[2]](diffhunk://#diff-3027336169662eef4888f5ec50e4b5184f7aca90993e0a2b9d733d41d6bebcb8L56-R66)