### PR TITLE
fix: correctly parse peri numeric contrainsts to json-schema

### DIFF
--- a/lib/hermes/server/component/schema.ex
+++ b/lib/hermes/server/component/schema.ex
@@ -102,24 +102,56 @@ defmodule Hermes.Server.Component.Schema do
     %{"type" => "string", "maxLength" => max}
   end
 
-  defp convert_type({:integer, {:min, min}}) do
-    %{"type" => "integer", "minimum" => min}
+  defp convert_type({:integer, {:eq, value}}) do
+    %{"type" => "integer", "const" => value}
   end
 
-  defp convert_type({:integer, {:max, max}}) do
-    %{"type" => "integer", "maximum" => max}
+  defp convert_type({:integer, {:neq, value}}) do
+    %{"type" => "integer", "not" => %{"const" => value}}
+  end
+
+  defp convert_type({:integer, {:gt, value}}) do
+    %{"type" => "integer", "exclusiveMinimum" => value}
+  end
+
+  defp convert_type({:integer, {:gte, value}}) do
+    %{"type" => "integer", "minimum" => value}
+  end
+
+  defp convert_type({:integer, {:lt, value}}) do
+    %{"type" => "integer", "exclusiveMaximum" => value}
+  end
+
+  defp convert_type({:integer, {:lte, value}}) do
+    %{"type" => "integer", "maximum" => value}
   end
 
   defp convert_type({:integer, {:range, {min, max}}}) do
     %{"type" => "integer", "minimum" => min, "maximum" => max}
   end
 
-  defp convert_type({:float, {:min, min}}) do
-    %{"type" => "number", "minimum" => min}
+  defp convert_type({:float, {:eq, value}}) do
+    %{"type" => "number", "const" => value}
   end
 
-  defp convert_type({:float, {:max, max}}) do
-    %{"type" => "number", "maximum" => max}
+  defp convert_type({:float, {:neq, value}}) do
+    %{"type" => "number", "not" => %{"const" => value}}
+  end
+
+  defp convert_type({:float, {:gt, value}}) do
+    %{"type" => "number", "exclusiveMinimum" => value}
+  end
+
+  defp convert_type({:float, {:gte, value}}) do
+    %{"type" => "number", "minimum" => value}
+  end
+
+  defp convert_type({:float, {:lt, value}}) do
+    %{"type" => "number", "exclusiveMaximum" => value}
+  end
+
+  defp convert_type({:float, {:lte, value}}) do
+    %{"type" => "number", "maximum" => value}
   end
 
   defp convert_type({:float, {:range, {min, max}}}) do

--- a/pages/server_components.md
+++ b/pages/server_components.md
@@ -598,9 +598,21 @@ end
 | `{:enum, choices}` | Value must be one of the choices | `{:enum, ["active", "inactive"]}` * |
 | `{:string, {:min, n}}` | String with minimum length | `{:string, {:min, 3}}` |
 | `{:string, {:max, n}}` | String with maximum length | `{:string, {:max, 100}}` |
-| `{:integer, {:min, n}}` | Integer >= n | `{:integer, {:min, 0}}` |
-| `{:integer, {:max, n}}` | Integer <= n | `{:integer, {:max, 100}}` |
-| `{:integer, {:range, {min, max}}}` | Integer in range | `{:integer, {:range, {1, 100}}}` |
+| `{:string, {:regex, pattern}}` | String matching regex pattern | `{:string, {:regex, ~r/^[A-Z]+$/}}` |
+| `{:integer, {:eq, n}}` | Integer equal to n | `{:integer, {:eq, 42}}` |
+| `{:integer, {:neq, n}}` | Integer not equal to n | `{:integer, {:neq, 0}}` |
+| `{:integer, {:gt, n}}` | Integer > n | `{:integer, {:gt, 0}}` |
+| `{:integer, {:gte, n}}` | Integer >= n | `{:integer, {:gte, 18}}` |
+| `{:integer, {:lt, n}}` | Integer < n | `{:integer, {:lt, 100}}` |
+| `{:integer, {:lte, n}}` | Integer <= n | `{:integer, {:lte, 99}}` |
+| `{:integer, {:range, {min, max}}}` | Integer in range [min, max] | `{:integer, {:range, {1, 100}}}` |
+| `{:float, {:eq, n}}` | Float equal to n | `{:float, {:eq, 3.14}}` |
+| `{:float, {:neq, n}}` | Float not equal to n | `{:float, {:neq, 0.0}}` |
+| `{:float, {:gt, n}}` | Float > n | `{:float, {:gt, 0.0}}` |
+| `{:float, {:gte, n}}` | Float >= n | `{:float, {:gte, 1.5}}` |
+| `{:float, {:lt, n}}` | Float < n | `{:float, {:lt, 100.0}}` |
+| `{:float, {:lte, n}}` | Float <= n | `{:float, {:lte, 99.9}}` |
+| `{:float, {:range, {min, max}}}` | Float in range [min, max] | `{:float, {:range, {1.0, 100.0}}}` |
 
 \* Note: When using enum with the field macro, add `type: :string` for proper JSON Schema generation.
 

--- a/test/hermes/server/component/schema_test.exs
+++ b/test/hermes/server/component/schema_test.exs
@@ -79,24 +79,52 @@ defmodule Hermes.Server.Component.SchemaTest do
 
     test "converts numeric constraints" do
       schema = %{
-        min_int: {:integer, {:min, 0}},
-        max_int: {:integer, {:max, 100}},
+        eq_int: {:integer, {:eq, 42}},
+        neq_int: {:integer, {:neq, 0}},
+        gt_int: {:integer, {:gt, 0}},
+        gte_int: {:integer, {:gte, 18}},
+        lt_int: {:integer, {:lt, 100}},
+        lte_int: {:integer, {:lte, 99}},
         range_int: {:integer, {:range, {1, 10}}},
-        min_float: {:float, {:min, 0.0}},
-        max_float: {:float, {:max, 100.0}},
+        eq_float: {:float, {:eq, 3.14}},
+        neq_float: {:float, {:neq, 0.0}},
+        gt_float: {:float, {:gt, 0.0}},
+        gte_float: {:float, {:gte, 1.5}},
+        lt_float: {:float, {:lt, 100.0}},
+        lte_float: {:float, {:lte, 99.9}},
         range_float: {:float, {:range, {1.0, 10.0}}}
       }
 
       result = Schema.to_json_schema(schema)
 
-      assert result["properties"]["min_int"] == %{
+      assert result["properties"]["eq_int"] == %{
                "type" => "integer",
-               "minimum" => 0
+               "const" => 42
              }
 
-      assert result["properties"]["max_int"] == %{
+      assert result["properties"]["neq_int"] == %{
                "type" => "integer",
-               "maximum" => 100
+               "not" => %{"const" => 0}
+             }
+
+      assert result["properties"]["gt_int"] == %{
+               "type" => "integer",
+               "exclusiveMinimum" => 0
+             }
+
+      assert result["properties"]["gte_int"] == %{
+               "type" => "integer",
+               "minimum" => 18
+             }
+
+      assert result["properties"]["lt_int"] == %{
+               "type" => "integer",
+               "exclusiveMaximum" => 100
+             }
+
+      assert result["properties"]["lte_int"] == %{
+               "type" => "integer",
+               "maximum" => 99
              }
 
       assert result["properties"]["range_int"] == %{
@@ -105,14 +133,34 @@ defmodule Hermes.Server.Component.SchemaTest do
                "maximum" => 10
              }
 
-      assert result["properties"]["min_float"] == %{
+      assert result["properties"]["eq_float"] == %{
                "type" => "number",
-               "minimum" => 0.0
+               "const" => 3.14
              }
 
-      assert result["properties"]["max_float"] == %{
+      assert result["properties"]["neq_float"] == %{
                "type" => "number",
-               "maximum" => 100.0
+               "not" => %{"const" => 0.0}
+             }
+
+      assert result["properties"]["gt_float"] == %{
+               "type" => "number",
+               "exclusiveMinimum" => 0.0
+             }
+
+      assert result["properties"]["gte_float"] == %{
+               "type" => "number",
+               "minimum" => 1.5
+             }
+
+      assert result["properties"]["lt_float"] == %{
+               "type" => "number",
+               "exclusiveMaximum" => 100.0
+             }
+
+      assert result["properties"]["lte_float"] == %{
+               "type" => "number",
+               "maximum" => 99.9
              }
 
       assert result["properties"]["range_float"] == %{


### PR DESCRIPTION
This pull request enhances support for numeric constraints in the `Hermes.Server.Component.Schema` module by introducing new constraint types for integers and floats. It also updates the documentation and tests to reflect these changes.

### Enhancements to Numeric Constraints:

* Added support for new integer constraints: `{:eq, value}`, `{:neq, value}`, `{:gt, value}`, `{:gte, value}`, `{:lt, value}`, and `{:lte, value}`. These map to JSON Schema properties like `const`, `not`, `exclusiveMinimum`, and `exclusiveMaximum`.
* Added support for equivalent float constraints: `{:eq, value}`, `{:neq, value}`, `{:gt, value}`, `{:gte, value}`, `{:lt, value}`, and `{:lte, value}`.

### Documentation Updates:

* Updated `pages/server_components.md` to document the new integer and float constraints, including examples for each.

### Test Coverage Improvements:

* Expanded tests in `test/hermes/server/component/schema_test.exs` to validate the new constraints for both integers and floats, ensuring correct JSON Schema generation. [[1]](diffhunk://#diff-988e89582bb75ae7a4d1cfeeaf9e2b2f9aef3d71780d3698c4f59d2126c14500L82-R127) [[2]](diffhunk://#diff-988e89582bb75ae7a4d1cfeeaf9e2b2f9aef3d71780d3698c4f59d2126c14500L108-R163)