### PR TITLE
chore: ci on elixir matrix versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        elixir: [1.19.0-rc.0]
+        elixir: [1.17, 1.18, 1.19.0-rc.0]
         otp: [27.3]
 
     steps:
@@ -72,7 +72,7 @@ jobs:
 
     strategy:
       matrix:
-        elixir: [1.19.0-rc.0]
+        elixir: [1.17, 1.18, 1.19.0-rc.0]
         otp: [27.3]
 
     steps:
@@ -140,7 +140,7 @@ jobs:
 
     strategy:
       matrix:
-        elixir: [1.19.0-rc.0]
+        elixir: [1.17, 1.18, 1.19.0-rc.0]
         otp: [27.3]
 
     steps:


### PR DESCRIPTION
This pull request updates the CI workflow to expand the matrix of Elixir versions being tested. The changes ensure compatibility with multiple Elixir versions, enhancing the robustness of the CI pipeline.

### CI Workflow Updates:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL20-R20): Updated the Elixir version matrix in three separate job configurations to include versions `1.17`, `1.18`, and `1.19.0-rc.0` for broader compatibility testing. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL20-R20) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL75-R75) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL143-R143)