### PR TITLE
fix: server can now send notifications correctly

### DIFF
--- a/lib/hermes/server/frame.ex
+++ b/lib/hermes/server/frame.ex
@@ -50,7 +50,7 @@ defmodule Hermes.Server.Frame do
   These fields are reserved for framework usage:
 
     * `private` - shared framework data as a map. Contains MCP session context:
-      * `session_id` - unique identifier for the client session
+      * `session_id` - unique identifier for the current client session being handled
       * `client_info` - client information from initialization, example: `%{"name" => "my-client", "version" => "1.0.0"}`
       * `client_capabilities` - negotiated client capabilities
       * `protocol_version` - active MCP protocol version, example: `"2025-03-26"`

--- a/lib/hermes/server/session.ex
+++ b/lib/hermes/server/session.ex
@@ -40,40 +40,17 @@ defmodule Hermes.Server.Session do
 
   @doc """
   Creates a new server state with the given options.
-
-  ## Parameters
-
-    * `opts` - Map containing the initialization options
   """
   @spec new(Enumerable.t()) :: t()
   def new(opts), do: struct(__MODULE__, opts)
 
   @doc """
   Guard to check if a session has been initialized.
-
-  ## Examples
-
-      iex> session = %Session{initialized: true}
-      iex> is_initialized(session)
-      true
   """
   defguard is_initialized(session) when session.initialized
 
   @doc """
   Retrieves the current state of a session.
-
-  ## Parameters
-
-    * `session` - The session agent name or PID
-
-  ## Returns
-
-  The current session state as a `%Session{}` struct.
-
-  ## Examples
-
-      iex> session_state = Session.get(session_name)
-      %Session{initialized: true, protocol_version: "2025-03-26"}
   """
   @spec get(GenServer.name()) :: t
   def get(session) do
@@ -87,20 +64,6 @@ defmodule Hermes.Server.Session do
   1. Sets the negotiated protocol version
   2. Stores client information and capabilities
   3. Marks the server as initialized
-
-  ## Parameters
-
-    * `state` - The current server state
-    * `protocol_version` - The negotiated protocol version
-    * `client_info` - Client information from the initialize request
-    * `client_capabilities` - Client capabilities from the initialize request
-
-  ## Examples
-
-      iex> client_info = %{"name" => "hello", "version" => "1.0.0"}
-      iex> capabilities = %{"sampling" => %{}}
-      iex> Hermes.Server.Session.update_from_initialization(session, "2025-03-26", client_info, capabilities)
-      :ok
   """
   @spec update_from_initialization(GenServer.name(), String.t(), map, map) :: :ok
   def update_from_initialization(
@@ -137,17 +100,6 @@ defmodule Hermes.Server.Session do
 
   @doc """
   Tracks a new pending request in the session.
-
-  ## Parameters
-
-    * `session` - The session agent name or PID
-    * `request_id` - The unique request ID
-    * `method` - The MCP method being called
-
-  ## Examples
-
-      iex> Session.track_request(session, "req_123", "tools/call")
-      :ok
   """
   @spec track_request(GenServer.name(), String.t(), String.t()) :: :ok
   def track_request(session, request_id, method) do
@@ -166,20 +118,6 @@ defmodule Hermes.Server.Session do
 
   @doc """
   Removes a completed request from tracking.
-
-  ## Parameters
-
-    * `session` - The session agent name or PID
-    * `request_id` - The request ID to remove
-
-  ## Returns
-
-  The request info if found, nil otherwise.
-
-  ## Examples
-
-      iex> Session.complete_request(session, "req_123")
-      %{started_at: 1234567890, method: "tools/call"}
   """
   @spec complete_request(GenServer.name(), String.t()) :: map() | nil
   def complete_request(session, request_id) do
@@ -191,16 +129,6 @@ defmodule Hermes.Server.Session do
 
   @doc """
   Checks if a request is currently pending.
-
-  ## Parameters
-
-    * `session` - The session agent name or PID
-    * `request_id` - The request ID to check
-
-  ## Examples
-
-      iex> Session.has_pending_request?(session, "req_123")
-      true
   """
   @spec has_pending_request?(GenServer.name(), String.t()) :: boolean()
   def has_pending_request?(session, request_id) do
@@ -211,15 +139,6 @@ defmodule Hermes.Server.Session do
 
   @doc """
   Gets all pending requests for a session.
-
-  ## Parameters
-
-    * `session` - The session agent name or PID
-
-  ## Examples
-
-      iex> Session.get_pending_requests(session)
-      %{"req_123" => %{started_at: 1234567890, method: "tools/call"}}
   """
   @spec get_pending_requests(GenServer.name()) :: map()
   def get_pending_requests(session) do

--- a/test/hermes/server/base_test.exs
+++ b/test/hermes/server/base_test.exs
@@ -86,9 +86,7 @@ defmodule Hermes.Server.BaseTest do
     setup :initialized_server
 
     test "sends notification to transport", %{server: server} do
-      params = %{"logger" => "database", "level" => "error", "data" => %{}}
-      assert :ok = Base.send_notification(server, "notifications/message", params)
-      # TODO(zoedsoupe): assert on StubTransport
+      assert :ok = Hermes.Server.send_log_message(server, :info, "hello")
     end
   end
 


### PR DESCRIPTION
## Problem

helper functions for servers send notifications were implemented as handle_call/handle_cast on the Base module, which causes a deadlock, raising a "process tried to call itself" exception

## Solution

move those helpers to the Server module and send messages as handle_info to the Base process, that way it can handle it correctly

## Rationale

N/A
