### PR TITLE
feat: client sampling capability

### DIFF
--- a/lib/hermes/client/state.ex
+++ b/lib/hermes/client/state.ex
@@ -18,6 +18,7 @@ defmodule Hermes.Client.State do
           pending_requests: %{String.t() => Request.t()},
           progress_callbacks: %{String.t() => Base.progress_callback()},
           log_callback: Base.log_callback() | nil,
+          sampling_callback: (map() -> {:ok, map()} | {:error, String.t()}) | nil,
           # Use a map with URI as key for faster access
           roots: %{String.t() => Base.root()}
         }
@@ -32,6 +33,7 @@ defmodule Hermes.Client.State do
     pending_requests: %{},
     progress_callbacks: %{},
     log_callback: nil,
+    sampling_callback: nil,
     roots: %{}
   ]
 
@@ -652,6 +654,63 @@ defmodule Hermes.Client.State do
   @spec batch_complete?(t(), String.t()) :: boolean()
   def batch_complete?(state, batch_id) do
     get_batch_requests(state, batch_id) == []
+  end
+
+  @doc """
+  Sets the sampling callback function.
+
+  ## Parameters
+
+    * `state` - The current client state
+    * `callback` - The callback function to handle sampling requests
+
+  ## Examples
+
+      iex> callback = fn params -> {:ok, %{role: "assistant", content: %{type: "text", text: "Hello"}}} end
+      iex> updated_state = Hermes.Client.State.set_sampling_callback(state, callback)
+      iex> is_function(updated_state.sampling_callback, 1)
+      true
+  """
+  @spec set_sampling_callback(t(), (map() -> {:ok, map()} | {:error, String.t()})) ::
+          t()
+  def set_sampling_callback(state, callback) when is_function(callback, 1) do
+    %{state | sampling_callback: callback}
+  end
+
+  @doc """
+  Gets the sampling callback function.
+
+  ## Parameters
+
+    * `state` - The current client state
+
+  ## Examples
+
+      iex> Hermes.Client.State.get_sampling_callback(state)
+      nil
+  """
+  @spec get_sampling_callback(t()) ::
+          (map() -> {:ok, map()} | {:error, String.t()}) | nil
+  def get_sampling_callback(state) do
+    state.sampling_callback
+  end
+
+  @doc """
+  Clears the sampling callback function.
+
+  ## Parameters
+
+    * `state` - The current client state
+
+  ## Examples
+
+      iex> updated_state = Hermes.Client.State.clear_sampling_callback(state)
+      iex> updated_state.sampling_callback
+      nil
+  """
+  @spec clear_sampling_callback(t()) :: t()
+  def clear_sampling_callback(state) do
+    %{state | sampling_callback: nil}
   end
 
   # Helper functions

--- a/test/support/mcp/setup.ex
+++ b/test/support/mcp/setup.ex
@@ -98,8 +98,8 @@ defmodule Hermes.MCP.Setup do
 
     Process.sleep(80)
 
-    assert_client_initialized client
-    assert_server_initialized server
+    assert_client_initialized(client)
+    assert_server_initialized(server)
 
     :ok = StubTransport.clear(transport)
 
@@ -126,7 +126,7 @@ defmodule Hermes.MCP.Setup do
 
     Process.sleep(50)
 
-    assert_server_initialized server
+    assert_server_initialized(server)
 
     :ok = StubTransport.clear(transport)
 
@@ -181,7 +181,7 @@ defmodule Hermes.MCP.Setup do
 
     Process.sleep(50)
 
-    assert_server_initialized server
+    assert_server_initialized(server)
 
     :ok = StubTransport.clear(transport)
 
@@ -233,7 +233,7 @@ defmodule Hermes.MCP.Setup do
     client_info =
       context[:client_info] || %{"name" => "TestClient", "version" => "1.0.0"}
 
-    client_capabilities = context[:client_capabilities]
+    client_capabilities = context[:client_capabilities] || %{}
 
     client =
       start_supervised!(


### PR DESCRIPTION
This pull request introduces a new feature to handle "sampling/createMessage" requests in the Hermes client, along with associated changes to support this functionality. Key updates include adding a sampling callback mechanism, extending the message schema, and updating the client state and tests.

### Sampling Feature Implementation:

* Added a new method `register_sampling_callback` to allow clients to register a callback for handling "sampling/createMessage" requests. This includes a corresponding method to unregister the callback. (`lib/hermes/client/base.ex`, [[1]](diffhunk://#diff-bfaef6ab59ba5bb96855ede4ff713c9f7923f2fc2937f45031f1f33f3e3f009aR732-R780) [[2]](diffhunk://#diff-bfaef6ab59ba5bb96855ede4ff713c9f7923f2fc2937f45031f1f33f3e3f009aR879-R886)
* Implemented server request handling for "sampling/createMessage", including validation of capabilities, execution of the callback, and sending appropriate responses or errors. (`lib/hermes/client/base.ex`, [[1]](diffhunk://#diff-bfaef6ab59ba5bb96855ede4ff713c9f7923f2fc2937f45031f1f33f3e3f009aR1106-R1120) [[2]](diffhunk://#diff-bfaef6ab59ba5bb96855ede4ff713c9f7923f2fc2937f45031f1f33f3e3f009aR1643-R1763)

### Schema and State Updates:

* Extended the `Hermes.MCP.Message` module with new schemas for sampling requests and responses, including support for text, image, and audio content types. (`lib/hermes/mcp/message.ex`, [[1]](diffhunk://#diff-4104d9ed3b4233021101bf919b762172bed832043927316b83d52cbf5ea6dcb3L85-R128) [[2]](diffhunk://#diff-4104d9ed3b4233021101bf919b762172bed832043927316b83d52cbf5ea6dcb3L188-R275) [[3]](diffhunk://#diff-4104d9ed3b4233021101bf919b762172bed832043927316b83d52cbf5ea6dcb3R576-R579)
* Updated the client state to include a `sampling_callback` field and added helper functions to set, get, and clear this callback. (`lib/hermes/client/state.ex`, [[1]](diffhunk://#diff-a625e24af41ec83d08958576bd792f07276ddd12cb2745c43eae3627b4dd4508R21) [[2]](diffhunk://#diff-a625e24af41ec83d08958576bd792f07276ddd12cb2745c43eae3627b4dd4508R659-R715)

### Default Capabilities and Tests:

* Removed the default client capabilities and made the `capabilities` field required in the client options. Updated tests to reflect this change. (`lib/hermes/client/base.ex`, [[1]](diffhunk://#diff-bfaef6ab59ba5bb96855ede4ff713c9f7923f2fc2937f45031f1f33f3e3f009aL136-R140); `test/hermes/client/base_test.exs`, [[2]](diffhunk://#diff-01d54fe15ba0e2863ac2d6cdbdca4000baa23c0d290b458427d686e5a13668e9L33-R34) [[3]](diffhunk://#diff-01d54fe15ba0e2863ac2d6cdbdca4000baa23c0d290b458427d686e5a13668e9L731-R733)