### PR TITLE
feat: server components cursor pagination

### DIFF
--- a/lib/hermes/server.ex
+++ b/lib/hermes/server.ex
@@ -496,7 +496,9 @@ defmodule Hermes.Server do
 
   @doc false
   def parse_components(components) when is_list(components) do
-    Enum.flat_map(components, &parse_components/1)
+    components
+    |> Enum.flat_map(&parse_components/1)
+    |> Enum.sort_by(& &1.name)
   end
 
   def parse_components({:tool, name, mod}) do

--- a/lib/hermes/server/frame.ex
+++ b/lib/hermes/server/frame.ex
@@ -69,6 +69,9 @@ defmodule Hermes.Server.Frame do
           optional(:client_info) => map(),
           optional(:client_capabilities) => map(),
           optional(:protocol_version) => String.t(),
+          optional(:server_module) => module(),
+          optional(:server_registry) => module(),
+          optional(:pagination_limit) => non_neg_integer(),
           optional(:__mcp_components__) => list(server_component_t)
         }
 
@@ -252,6 +255,28 @@ defmodule Hermes.Server.Frame do
   @spec put_request(t, map) :: t
   def put_request(%__MODULE__{} = frame, request) when is_map(request) do
     %{frame | request: request}
+  end
+
+  @doc """
+  Sets the pagination limit for listing operations.
+
+  This limit is used by handlers when returning lists of tools, prompts, or resources
+  to control the maximum number of items returned in a single response. When the limit
+  is set and the total number of items exceeds it, the response will include a
+  `nextCursor` field for pagination.
+
+  ## Examples
+
+      # Set pagination limit to 10 items per page
+      frame = Frame.put_pagination_limit(frame, 10)
+
+      # The limit is stored in private data
+      frame.private.pagination_limit
+      # => 10
+  """
+  @spec put_pagination_limit(t, non_neg_integer) :: t
+  def put_pagination_limit(%__MODULE__{} = frame, limit) when limit > 0 do
+    put_private(frame, %{pagination_limit: limit})
   end
 
   @doc """

--- a/priv/dev/upcase/lib/upcase/server.ex
+++ b/priv/dev/upcase/lib/upcase/server.ex
@@ -31,7 +31,7 @@ defmodule Upcase.Server do
   def init(client_info, frame) do
     Logger.info("We had the client_info: #{inspect(client_info)}")
     schedule_hello()
-    {:ok, assign(frame, counter: 0)}
+    {:ok, assign(frame, counter: 0) |> put_pagination_limit(1)}
   end
 
   @impl true

--- a/test/hermes/server/handlers_test.exs
+++ b/test/hermes/server/handlers_test.exs
@@ -1,0 +1,299 @@
+defmodule Hermes.Server.HandlersTest do
+  use ExUnit.Case, async: true
+
+  alias Hermes.Server.Component.Prompt
+  alias Hermes.Server.Component.Resource
+  alias Hermes.Server.Component.Tool
+  alias Hermes.Server.Frame
+  alias Hermes.Server.Handlers
+
+  defmodule MockServer do
+    @moduledoc false
+    def __components__(:tool) do
+      [
+        %Tool{name: "tool_a", description: "Tool A"},
+        %Tool{name: "tool_b", description: "Tool B"},
+        %Tool{name: "tool_c", description: "Tool C"},
+        %Tool{name: "tool_d", description: "Tool D"}
+      ]
+    end
+
+    def __components__(:prompt) do
+      [
+        %Prompt{name: "prompt_1", description: "Prompt 1"},
+        %Prompt{name: "prompt_2", description: "Prompt 2"},
+        %Prompt{name: "prompt_3", description: "Prompt 3"}
+      ]
+    end
+
+    def __components__(:resource) do
+      [
+        %Resource{uri: "resource://a", name: "resource_a", mime_type: "text/plain"},
+        %Resource{uri: "resource://b", name: "resource_b", mime_type: "text/plain"},
+        %Resource{uri: "resource://c", name: "resource_c", mime_type: "text/plain"},
+        %Resource{uri: "resource://d", name: "resource_d", mime_type: "text/plain"},
+        %Resource{uri: "resource://e", name: "resource_e", mime_type: "text/plain"}
+      ]
+    end
+  end
+
+  describe "maybe_paginate/3" do
+    test "returns all items when limit is nil" do
+      components = [
+        %Tool{name: "a"},
+        %Tool{name: "b"},
+        %Tool{name: "c"}
+      ]
+
+      assert {^components, nil} = Handlers.maybe_paginate(%{}, components, nil)
+    end
+
+    test "paginates items when limit is set" do
+      components = [
+        %Tool{name: "a"},
+        %Tool{name: "b"},
+        %Tool{name: "c"},
+        %Tool{name: "d"}
+      ]
+
+      {items, cursor} = Handlers.maybe_paginate(%{}, components, 2)
+      assert length(items) == 2
+      assert [%Tool{name: "a"}, %Tool{name: "b"}] = items
+      assert cursor == Base.encode64("b", padding: false)
+    end
+
+    test "returns nil cursor when items don't exceed limit" do
+      components = [
+        %Tool{name: "a"},
+        %Tool{name: "b"}
+      ]
+
+      {items, cursor} = Handlers.maybe_paginate(%{}, components, 5)
+      assert length(items) == 2
+      assert cursor == nil
+    end
+
+    test "handles cursor-based pagination" do
+      components = [
+        %Tool{name: "a"},
+        %Tool{name: "b"},
+        %Tool{name: "c"},
+        %Tool{name: "d"}
+      ]
+
+      cursor = Base.encode64("b", padding: false)
+      request = %{"params" => %{"cursor" => cursor}}
+
+      {items, next_cursor} = Handlers.maybe_paginate(request, components, 2)
+      assert length(items) == 2
+      assert [%Tool{name: "c"}, %Tool{name: "d"}] = items
+      refute next_cursor
+    end
+
+    test "returns empty list when cursor is beyond all items" do
+      components = [
+        %Tool{name: "a"},
+        %Tool{name: "b"}
+      ]
+
+      cursor = Base.encode64("z", padding: false)
+      request = %{"params" => %{"cursor" => cursor}}
+
+      {items, next_cursor} = Handlers.maybe_paginate(request, components, 2)
+      assert items == []
+      assert next_cursor == nil
+    end
+  end
+
+  describe "tools/list with pagination" do
+    setup do
+      frame = Frame.new()
+      {:ok, frame: frame}
+    end
+
+    test "returns paginated tools when limit is set", %{frame: frame} do
+      frame = Frame.put_pagination_limit(frame, 2)
+      request = %{"method" => "tools/list", "params" => %{}}
+
+      {:reply, response, _frame} = Handlers.handle(request, MockServer, frame)
+
+      assert length(response["tools"]) == 2
+      assert response["nextCursor"]
+      assert [%{name: "tool_a"}, %{name: "tool_b"}] = response["tools"]
+    end
+
+    test "returns all tools when no limit is set", %{frame: frame} do
+      request = %{"method" => "tools/list", "params" => %{}}
+
+      {:reply, response, _frame} = Handlers.handle(request, MockServer, frame)
+
+      assert length(response["tools"]) == 4
+      refute Map.has_key?(response, "nextCursor")
+    end
+
+    test "handles cursor-based pagination", %{frame: frame} do
+      frame = Frame.put_pagination_limit(frame, 2)
+      cursor = Base.encode64("tool_b", padding: false)
+      request = %{"method" => "tools/list", "params" => %{"cursor" => cursor}}
+
+      {:reply, response, _frame} = Handlers.handle(request, MockServer, frame)
+
+      assert length(response["tools"]) == 2
+      refute response["nextCursor"]
+      assert [%{name: "tool_c"}, %{name: "tool_d"}] = response["tools"]
+    end
+  end
+
+  describe "prompts/list with pagination" do
+    setup do
+      frame = Frame.new()
+      {:ok, frame: frame}
+    end
+
+    test "returns paginated prompts when limit is set", %{frame: frame} do
+      frame = Frame.put_pagination_limit(frame, 2)
+      request = %{"method" => "prompts/list", "params" => %{}}
+
+      {:reply, response, _frame} = Handlers.handle(request, MockServer, frame)
+
+      assert length(response["prompts"]) == 2
+      assert response["nextCursor"]
+      assert [%{name: "prompt_1"}, %{name: "prompt_2"}] = response["prompts"]
+    end
+
+    test "returns all prompts when no limit is set", %{frame: frame} do
+      request = %{"method" => "prompts/list", "params" => %{}}
+
+      {:reply, response, _frame} = Handlers.handle(request, MockServer, frame)
+
+      assert length(response["prompts"]) == 3
+      refute Map.has_key?(response, "nextCursor")
+    end
+
+    test "handles last page correctly", %{frame: frame} do
+      frame = Frame.put_pagination_limit(frame, 2)
+      cursor = Base.encode64("prompt_2", padding: false)
+      request = %{"method" => "prompts/list", "params" => %{"cursor" => cursor}}
+
+      {:reply, response, _frame} = Handlers.handle(request, MockServer, frame)
+
+      assert length(response["prompts"]) == 1
+      refute Map.has_key?(response, "nextCursor")
+      assert [%{name: "prompt_3"}] = response["prompts"]
+    end
+  end
+
+  describe "resources/list with pagination" do
+    setup do
+      frame = Frame.new()
+      {:ok, frame: frame}
+    end
+
+    test "returns paginated resources when limit is set", %{frame: frame} do
+      frame = Frame.put_pagination_limit(frame, 3)
+      request = %{"method" => "resources/list", "params" => %{}}
+
+      {:reply, response, _frame} = Handlers.handle(request, MockServer, frame)
+
+      assert length(response["resources"]) == 3
+      assert response["nextCursor"]
+
+      assert [
+               %{name: "resource_a"},
+               %{name: "resource_b"},
+               %{name: "resource_c"}
+             ] = response["resources"]
+    end
+
+    test "returns all resources when no limit is set", %{frame: frame} do
+      request = %{"method" => "resources/list", "params" => %{}}
+
+      {:reply, response, _frame} = Handlers.handle(request, MockServer, frame)
+
+      assert length(response["resources"]) == 5
+      refute Map.has_key?(response, "nextCursor")
+    end
+
+    test "handles multiple pages", %{frame: frame} do
+      frame = Frame.put_pagination_limit(frame, 2)
+
+      request1 = %{"method" => "resources/list", "params" => %{}}
+      {:reply, response1, _frame} = Handlers.handle(request1, MockServer, frame)
+
+      assert length(response1["resources"]) == 2
+      assert response1["nextCursor"]
+
+      request2 = %{
+        "method" => "resources/list",
+        "params" => %{"cursor" => response1["nextCursor"]}
+      }
+
+      {:reply, response2, _frame} = Handlers.handle(request2, MockServer, frame)
+
+      assert length(response2["resources"]) == 2
+      assert response2["nextCursor"]
+
+      request3 = %{
+        "method" => "resources/list",
+        "params" => %{"cursor" => response2["nextCursor"]}
+      }
+
+      {:reply, response3, _frame} = Handlers.handle(request3, MockServer, frame)
+
+      assert length(response3["resources"]) == 1
+      refute Map.has_key?(response3, "nextCursor")
+    end
+  end
+
+  describe "edge cases" do
+    setup do
+      frame = Frame.new()
+      {:ok, frame: frame}
+    end
+
+    test "handles empty component lists", %{frame: frame} do
+      defmodule EmptyServer do
+        @moduledoc false
+        def __components__(_), do: []
+      end
+
+      frame = Frame.put_pagination_limit(frame, 10)
+
+      for method <- ["tools/list", "prompts/list", "resources/list"] do
+        request = %{"method" => method, "params" => %{}}
+        {:reply, response, _frame} = Handlers.handle(request, EmptyServer, frame)
+
+        key = method |> String.split("/") |> List.first()
+        assert response[key] == []
+        refute Map.has_key?(response, "nextCursor")
+      end
+    end
+
+    test "handles single item with pagination", %{frame: frame} do
+      defmodule SingleItemServer do
+        @moduledoc false
+        def __components__(:tool), do: [%Tool{name: "only_tool"}]
+        def __components__(:prompt), do: []
+        def __components__(:resource), do: []
+      end
+
+      frame = Frame.put_pagination_limit(frame, 1)
+      request = %{"method" => "tools/list", "params" => %{}}
+
+      {:reply, response, _frame} = Handlers.handle(request, SingleItemServer, frame)
+
+      assert length(response["tools"]) == 1
+      refute Map.has_key?(response, "nextCursor")
+    end
+
+    test "handles invalid cursor gracefully", %{frame: frame} do
+      frame = Frame.put_pagination_limit(frame, 2)
+
+      request = %{"method" => "tools/list", "params" => %{"cursor" => "invalid!!!"}}
+
+      assert_raise ArgumentError, fn ->
+        Handlers.handle(request, MockServer, frame)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request introduces pagination support for listing operations (`tools`, `prompts`, and `resources`) in the `Hermes.Server` module. It also includes refactoring to improve code maintainability and adds comprehensive test coverage for the new functionality.

### Pagination Support
* Added a `pagination_limit` field to the `Frame` struct and a new function `put_pagination_limit/2` to set this limit. This controls the maximum number of items returned in listing operations. (`lib/hermes/server/frame.ex`, [[1]](diffhunk://#diff-d296c5fa6a67da6ccd1e72c33584efa89ff5de71e9741185421804b20e16cac6R72-R74) [[2]](diffhunk://#diff-d296c5fa6a67da6ccd1e72c33584efa89ff5de71e9741185421804b20e16cac6R260-R281)
* Implemented the `maybe_paginate/3` function in `Handlers` to handle cursor-based pagination for listing operations. (`lib/hermes/server/handlers.ex`, [lib/hermes/server/handlers.exL17-R76](diffhunk://#diff-5ee7c09e108ce4d3293bbc1e296a6bb2153d6af86ee31a3de0d3d65e85fd366eL17-R76))

### Refactoring for Reusability
* Refactored `handle_list` functions in `tools`, `prompts`, and `resources` handlers to use shared helper functions (`get_server_tools`, `get_server_prompts`, `get_server_resources`) and the `maybe_paginate/3` function for pagination. (`lib/hermes/server/handlers/tools.ex`, [[1]](diffhunk://#diff-d3567f753b885bf32c43db7cf78bd4c958601dfdea27f787802b5748de793b06R8-R32); `lib/hermes/server/handlers/prompts.ex`, [[2]](diffhunk://#diff-ad22560050197980031b03b7d27c4698a2f74fe9dcbe28876207a5eadc9d896dR8-R32); `lib/hermes/server/handlers/resources.ex`, [[3]](diffhunk://#diff-404366dfe1c704d451a448a204d9d0170671ab3f9a0523b8faa35382c6a87f24R7-R27)

### Code Enhancements
* Updated the `parse_components/1` function in `Hermes.Server` to sort components by name for consistent ordering. (`lib/hermes/server.ex`, [lib/hermes/server.exL499-R501](diffhunk://#diff-c469cff77f8fc0dc67ccf2b3a9975cb87205eb3e7a3971bdb3e32039d980b4e0L499-R501))

### Test Coverage
* Added a new test module `Hermes.Server.HandlersTest` with extensive test cases for pagination logic, including edge cases such as empty components, single-item lists, and invalid cursors. (`test/hermes/server/handlers_test.exs`, [test/hermes/server/handlers_test.exsR1-R299](diffhunk://#diff-2509b3b55b04286b9aae68ef669e6e2382e58719216cdf2e63e39609759fdebaR1-R299))

### Example Usage
* Updated the `Upcase.Server` example to demonstrate setting a pagination limit. (`priv/dev/upcase/lib/upcase/server.ex`, [priv/dev/upcase/lib/upcase/server.exL34-R34](diffhunk://#diff-de433b226e4b584d142961ebd5bfd7ddef9a27c4b5897310a735fcee107c878cL34-R34))