### PR TITLE
feat: roots/list and completion features

### DIFF
--- a/lib/hermes/server/handlers.ex
+++ b/lib/hermes/server/handlers.ex
@@ -3,6 +3,7 @@ defmodule Hermes.Server.Handlers do
 
   alias Hermes.MCP.Error
   alias Hermes.Server.Frame
+  alias Hermes.Server.Handlers.Completion
   alias Hermes.Server.Handlers.Prompts
   alias Hermes.Server.Handlers.Resources
   alias Hermes.Server.Handlers.Tools
@@ -31,6 +32,10 @@ defmodule Hermes.Server.Handlers do
       "list" -> Resources.handle_list(request, frame, module)
       "read" -> Resources.handle_read(request, frame, module)
     end
+  end
+
+  def handle(%{"method" => "completion/complete"} = request, module, frame) do
+    Completion.handle_complete(request, frame, module)
   end
 
   def handle(%{"method" => method}, _module, frame) do

--- a/lib/hermes/server/handlers/completion.ex
+++ b/lib/hermes/server/handlers/completion.ex
@@ -1,0 +1,56 @@
+defmodule Hermes.Server.Handlers.Completion do
+  @moduledoc false
+
+  alias Hermes.MCP.Error
+  alias Hermes.Server.Frame
+  alias Hermes.Server.Response
+
+  @spec handle_complete(map(), Frame.t(), module()) ::
+          {:reply, map(), Frame.t()} | {:error, Error.t(), Frame.t()}
+  def handle_complete(%{"params" => params}, frame, server) do
+    %{"ref" => ref} = params
+    argument = Map.get(params, "argument", %{})
+
+    if Hermes.exported?(server, :handle_completion, 3) do
+      case server.handle_completion(ref, argument, frame) do
+        {:reply, %Response{type: :completion} = response, frame} ->
+          result = Response.to_protocol(response)
+          {:reply, %{"completion" => result}, frame}
+
+        {:reply, %{"values" => values}, frame} when is_list(values) ->
+          {:reply, %{"completion" => %{"values" => values}}, frame}
+
+        {:reply, %{"values" => values, "total" => total, "hasMore" => has_more}, frame} ->
+          result = %{
+            "completion" => %{
+              "values" => values,
+              "total" => total,
+              "hasMore" => has_more
+            }
+          }
+
+          {:reply, result, frame}
+
+        {:error, %Error{} = error, frame} ->
+          {:error, error, frame}
+      end
+    else
+      error =
+        Error.protocol(:method_not_found, %{
+          method: "completion/complete",
+          message: "Server does not implement handle_completion/3"
+        })
+
+      {:error, error, frame}
+    end
+  end
+
+  def handle_complete(%{}, frame, _server) do
+    error =
+      Error.protocol(:invalid_params, %{
+        message: "Missing required parameter: ref"
+      })
+
+    {:error, error, frame}
+  end
+end


### PR DESCRIPTION
## Problem

The Hermes MCP server implementation was missing several features from the latest MCP specification (2025-06-18), including:
- Completion support (completion/complete)
- Roots list capability (roots/list request from server to client)

## Solution

Implemented the missing MCP features:
1. Completion support: Added completion handler, extended Response module to support completion responses, and updated server
capabilities
2. Roots list: Added ability for server to query client for available root URIs with timeout and cancellation support

## Rationale

- Followed existing patterns in the codebase for consistency
- Used the Response builder pattern for completion responses
- Modeled roots/list after the existing sampling request pattern but simplified by removing unnecessary metadata parameter
