### PR TITLE
chore: allow different kind of components have the same name

### DIFF
--- a/lib/hermes/server/frame.ex
+++ b/lib/hermes/server/frame.ex
@@ -508,6 +508,10 @@ defmodule Hermes.Server.Frame do
 
   defp update_components(frame, component) do
     components = [component | get_components(frame)]
-    put_private(frame, :__mcp_components__, Enum.uniq_by(components, & &1.name))
+    put_private(frame, :__mcp_components__, Enum.uniq_by(components, &unique_component/1))
+  end
+
+  defp unique_component(%struct{name: name}) do
+    {struct, name}
   end
 end


### PR DESCRIPTION
This pull request refines the logic for managing components within the `Hermes.Server.Frame` module by introducing a helper function to ensure unique identification of components.

Enhancements to component management:

* [`lib/hermes/server/frame.ex`](diffhunk://#diff-d296c5fa6a67da6ccd1e72c33584efa89ff5de71e9741185421804b20e16cac6L511-R515): Replaced the uniqueness logic in `update_components/2` by introducing a new helper function `unique_component/1`. This function uniquely identifies components using a tuple of their struct and name, improving clarity and maintainability.