### PR TITLE
fix: allow configuring server request timeout

### DIFF
--- a/lib/hermes/server/transport/streamable_http.ex
+++ b/lib/hermes/server/transport/streamable_http.ex
@@ -71,11 +71,12 @@ defmodule Hermes.Server.Transport.StreamableHTTP do
           | {:name, GenServer.name()}
           | GenServer.option()
 
-  defschema :parse_options, [
+  defschema(:parse_options, [
     {:server, {:required, Hermes.get_schema(:process_name)}},
     {:name, {:required, {:custom, &Hermes.genserver_name/1}}},
-    {:registry, {:atom, {:default, Hermes.Server.Registry}}}
-  ]
+    {:registry, {:atom, {:default, Hermes.Server.Registry}}},
+    {:request_timeout, {:integer, {:default, to_timeout(second: 30)}}}
+  ])
 
   @doc """
   Starts the StreamableHTTP transport.
@@ -207,6 +208,7 @@ defmodule Hermes.Server.Transport.StreamableHTTP do
     state = %{
       server: server,
       registry: opts.registry,
+      request_timeout: opts.request_timeout,
       # Map of session_id => {pid, monitor_ref}
       sse_handlers: %{}
     }
@@ -245,6 +247,7 @@ defmodule Hermes.Server.Transport.StreamableHTTP do
   def handle_call({:handle_message, session_id, message, context}, _from, state)
       when is_map(message) do
     server = state.registry.whereis_server(state.server)
+    timeout = state.request_timeout
 
     cond do
       Message.is_notification(message) ->
@@ -256,7 +259,8 @@ defmodule Hermes.Server.Transport.StreamableHTTP do
         {:reply, {:ok, nil}, state}
 
       true ->
-        {:reply, forward_request_to_server(server, message, session_id, context), state}
+        {:reply, forward_request_to_server(server, message, session_id, context, timeout),
+         state}
     end
   end
 
@@ -332,6 +336,8 @@ defmodule Hermes.Server.Transport.StreamableHTTP do
   end
 
   defp handle_single_message(server, message, session_id, context, state) do
+    timeout = state.request_timeout
+
     if Message.is_notification(message) do
       GenServer.cast(server, {:notification, message, session_id, context})
       {:reply, {:ok, nil}, state}
@@ -339,16 +345,23 @@ defmodule Hermes.Server.Transport.StreamableHTTP do
       sse_handler? = Map.has_key?(state.sse_handlers, session_id)
 
       {:reply,
-       forward_request_to_server(server, message, session_id, context, sse_handler?),
-       state}
+       forward_request_to_server(
+         server,
+         message,
+         session_id,
+         context,
+         timeout,
+         sse_handler?
+       ), state}
     end
   end
 
   defp handle_batch(server, messages, session_id, context, state) do
     sse_handler? = Map.has_key?(state.sse_handlers, session_id)
+    timeout = state.request_timeout
+    msg = {:batch_request, messages, session_id, context}
 
-    with {:batch, responses} <-
-           GenServer.call(server, {:batch_request, messages, session_id, context}),
+    with {:batch, responses} <- GenServer.call(server, msg, timeout),
          {:ok, batch_response} <- Message.encode_batch(responses) do
       if sse_handler?,
         do: {:reply, {:sse, batch_response}, state},
@@ -367,9 +380,12 @@ defmodule Hermes.Server.Transport.StreamableHTTP do
          message,
          session_id,
          context,
+         timeout,
          has_sse_handler \\ false
        ) do
-    case GenServer.call(server, {:request, message, session_id, context}) do
+    msg = {:request, message, session_id, context}
+
+    case GenServer.call(server, msg, timeout) do
       {:ok, response} when has_sse_handler ->
         {:sse, response}
 

--- a/lib/hermes/server/transport/streamable_http.ex
+++ b/lib/hermes/server/transport/streamable_http.ex
@@ -278,6 +278,7 @@ defmodule Hermes.Server.Transport.StreamableHTTP do
   def handle_call({:handle_message_for_sse, session_id, message, context}, _from, state)
       when is_map(message) do
     server = state.registry.whereis_server(state.server)
+    timeout = state.request_timeout
 
     if Message.is_notification(message) do
       GenServer.cast(server, {:notification, message, session_id, context})
@@ -286,8 +287,14 @@ defmodule Hermes.Server.Transport.StreamableHTTP do
       sse_handler? = Map.has_key?(state.sse_handlers, session_id)
 
       {:reply,
-       forward_request_to_server(server, message, session_id, context, sse_handler?),
-       state}
+       forward_request_to_server(
+         server,
+         message,
+         session_id,
+         context,
+         timeout,
+         sse_handler?
+       ), state}
     end
   end
 


### PR DESCRIPTION
This pull request introduces enhancements to the Hermes server and its transport modules by adding support for configurable request timeouts. The changes ensure that timeout values can be customized for server requests and batch operations, improving flexibility and reliability across different transport implementations.

### Enhancements to Hermes Server Supervisor:

* Updated `start_option` type in `lib/hermes/server/supervisor.ex` to include `:request_timeout` and `:server_name`, allowing configuration of server request timeouts and custom server names.
* Modified child initialization logic to pass the `request_timeout` option to transport processes.

### Updates to Transport Modules:

#### SSE Transport (`lib/hermes/server/transport/sse.ex`):
* Added `:request_timeout` as a required schema option and integrated it into the transport state. [[1]](diffhunk://#diff-55b06b7bd9573939a623c1ed37d5f44e300842a5b8cdecfde8fbfb141613a447L84-R91) [[2]](diffhunk://#diff-55b06b7bd9573939a623c1ed37d5f44e300842a5b8cdecfde8fbfb141613a447R219)
* Updated message handling functions to use the configurable timeout when forwarding requests and batch requests to the server. [[1]](diffhunk://#diff-55b06b7bd9573939a623c1ed37d5f44e300842a5b8cdecfde8fbfb141613a447R254-R260) [[2]](diffhunk://#diff-55b06b7bd9573939a623c1ed37d5f44e300842a5b8cdecfde8fbfb141613a447R273-R276) [[3]](diffhunk://#diff-55b06b7bd9573939a623c1ed37d5f44e300842a5b8cdecfde8fbfb141613a447L338-R345) [[4]](diffhunk://#diff-55b06b7bd9573939a623c1ed37d5f44e300842a5b8cdecfde8fbfb141613a447L358-R367)

#### STDIO Transport (`lib/hermes/server/transport/stdio.ex`):
* Added `:request_timeout` as a required schema option and integrated it into the transport state. [[1]](diffhunk://#diff-61921887b952ce41ebfb436711dca9d7f8b7c6a9dfd56cc0c2a20baced77362fL41-R42) [[2]](diffhunk://#diff-61921887b952ce41ebfb436711dca9d7f8b7c6a9dfd56cc0c2a20baced77362fL109-R115)
* Updated message and batch processing functions to use the configurable timeout when interacting with the server. [[1]](diffhunk://#diff-61921887b952ce41ebfb436711dca9d7f8b7c6a9dfd56cc0c2a20baced77362fL254-R272) [[2]](diffhunk://#diff-61921887b952ce41ebfb436711dca9d7f8b7c6a9dfd56cc0c2a20baced77362fL288-R299) [[3]](diffhunk://#diff-61921887b952ce41ebfb436711dca9d7f8b7c6a9dfd56cc0c2a20baced77362fL300-R310)

#### Streamable HTTP Transport (`lib/hermes/server/transport/streamable_http.ex`):
* Added `:request_timeout` as a required schema option and integrated it into the transport state. [[1]](diffhunk://#diff-da9c9a7a019b46d51290734c0735d5901ec1f1ee58ee44dc8b68912164e90ba0L74-R79) [[2]](diffhunk://#diff-da9c9a7a019b46d51290734c0735d5901ec1f1ee58ee44dc8b68912164e90ba0R211)
* Enhanced single and batch message handling to include timeout configuration when forwarding requests to the server. [[1]](diffhunk://#diff-da9c9a7a019b46d51290734c0735d5901ec1f1ee58ee44dc8b68912164e90ba0R250) [[2]](diffhunk://#diff-da9c9a7a019b46d51290734c0735d5901ec1f1ee58ee44dc8b68912164e90ba0L259-R263) [[3]](diffhunk://#diff-da9c9a7a019b46d51290734c0735d5901ec1f1ee58ee44dc8b68912164e90ba0R339-R364) [[4]](diffhunk://#diff-da9c9a7a019b46d51290734c0735d5901ec1f1ee58ee44dc8b68912164e90ba0R383-R388)