### PR TITLE
feat: allow redact patterns on server assigns/data

### DIFF
--- a/pages/building-a-server.md
+++ b/pages/building-a-server.md
@@ -445,6 +445,37 @@ defmodule MyApp.ServerTest do
 end
 ```
 
+## Security Configuration
+
+### Sensitive Data Redaction
+
+Hermes automatically redacts sensitive internal data (like HTTP headers, environment variables) when logging errors or crashes. For your application's `assigns` data, you can configure custom redaction patterns:
+
+```elixir
+# In your config/config.exs or runtime.exs
+config :hermes_mcp,
+  MyApp.Server,
+  redact_patterns: [
+    "password",
+    "token",
+    "secret",
+    ~r/api[_-]?key/i,
+    ~r/auth/i
+  ]
+```
+
+Any assign key matching these patterns will be redacted as `[REDACTED]` in logs:
+
+```elixir
+# Original frame assigns
+%{api_key: "sk-123", username: "alice", password: "secret123"}
+
+# Appears in logs as
+%{api_key: "[REDACTED]", username: "alice", password: "[REDACTED]"}
+```
+
+This helps prevent accidental exposure of sensitive data in error logs or crash reports while maintaining debugging capabilities.
+
 ## What's Next?
 
 You've seen how to expose your Elixir application's capabilities to AI assistants. What patterns interest you most?


### PR DESCRIPTION
This pull request introduces a feature to sanitize and redact sensitive data in the Hermes server's internal state and logs, along with documentation updates to explain its configuration. The most important changes include the addition of sanitization logic in the `Hermes.Server.Base` module and new documentation for configuring sensitive data redaction.

### Sanitization logic for sensitive data:

* [`lib/hermes/server/base.ex`](diffhunk://#diff-1146a134b004c3f80ca5063ac01c480f7a3364c39d4ce152f102e24db0f18673R310-R317): Added a new `format_status` implementation to sanitize the server's state for logging. This includes helper functions like `sanitize_state`, `sanitize_frame`, and `sanitize_private` to redact sensitive data such as HTTP headers, environment variables, and application-specific assigns. [[1]](diffhunk://#diff-1146a134b004c3f80ca5063ac01c480f7a3364c39d4ce152f102e24db0f18673R310-R317) [[2]](diffhunk://#diff-1146a134b004c3f80ca5063ac01c480f7a3364c39d4ce152f102e24db0f18673R918-R1002)

### Documentation updates:

* [`pages/building-a-server.md`](diffhunk://#diff-f112045ebd79df2630af0cea8f65b72717ea2a002e77f18afca2e2cf47be5c64R448-R478): Added a "Security Configuration" section explaining how to configure sensitive data redaction patterns in the application's configuration. This includes examples of redaction patterns for keys like "password", "token", and regex patterns for API keys and authentication data.