### PR TITLE
feat: better dsl for embedded nested fields on server components

### DIFF
--- a/test/hermes/server/component_embeds_test.exs
+++ b/test/hermes/server/component_embeds_test.exs
@@ -1,0 +1,144 @@
+defmodule Hermes.Server.ComponentEmbedsTest do
+  use ExUnit.Case, async: true
+
+  alias Hermes.Server.Component
+
+  defmodule TestToolWithEmbedsMany do
+    @moduledoc "Test tool with embeds_many"
+
+    use Component, type: :tool
+
+    schema do
+      embeds_many :users, description: "user list" do
+        field(:id, :string, required: true, description: "user id")
+      end
+    end
+
+    def execute(params, _context), do: {:ok, params}
+  end
+
+  defmodule TestToolWithEmbedsOne do
+    @moduledoc "Test tool with embeds_one"
+
+    use Component, type: :tool
+
+    schema do
+      embeds_one :user, description: "user" do
+        field(:id, :string, required: true, description: "user id")
+      end
+    end
+
+    def execute(params, _context), do: {:ok, params}
+  end
+
+  defmodule TestToolWithRequiredEmbeds do
+    @moduledoc "Test tool with required embeds"
+
+    use Component, type: :tool
+
+    schema do
+      embeds_many :tags, required: true, description: "list of tags" do
+        field(:name, :string, required: true)
+        field(:value, :string)
+      end
+
+      embeds_one :metadata, required: true do
+        field(:version, :integer, required: true)
+      end
+    end
+
+    def execute(params, _context), do: {:ok, params}
+  end
+
+  describe "embeds_many" do
+    test "generates correct JSON schema for array of objects" do
+      schema = TestToolWithEmbedsMany.input_schema()
+
+      expected = %{
+        "type" => "object",
+        "properties" => %{
+          "users" => %{
+            "type" => "array",
+            "description" => "user list",
+            "items" => %{
+              "type" => "object",
+              "properties" => %{
+                "id" => %{
+                  "type" => "string",
+                  "description" => "user id"
+                }
+              },
+              "required" => ["id"]
+            }
+          }
+        }
+      }
+
+      assert schema == expected
+    end
+
+    test "validates input correctly" do
+      params = %{users: [%{id: "1"}, %{id: "2"}]}
+      assert {:ok, ^params} = TestToolWithEmbedsMany.mcp_schema(params)
+
+      params = %{users: [%{id: "1"}, %{name: "John"}]}
+      assert {:error, errors} = TestToolWithEmbedsMany.mcp_schema(params)
+      assert is_list(errors)
+    end
+  end
+
+  describe "embeds_one" do
+    test "generates correct JSON schema for single object" do
+      schema = TestToolWithEmbedsOne.input_schema()
+
+      expected = %{
+        "type" => "object",
+        "properties" => %{
+          "user" => %{
+            "type" => "object",
+            "description" => "user",
+            "properties" => %{
+              "id" => %{
+                "type" => "string",
+                "description" => "user id"
+              }
+            },
+            "required" => ["id"]
+          }
+        }
+      }
+
+      assert schema == expected
+    end
+
+    test "validates input correctly" do
+      params = %{user: %{id: "1"}}
+      assert {:ok, ^params} = TestToolWithEmbedsOne.mcp_schema(params)
+
+      params = %{user: %{name: "John"}}
+      assert {:error, errors} = TestToolWithEmbedsOne.mcp_schema(params)
+      assert is_list(errors)
+    end
+  end
+
+  describe "required embeds" do
+    test "generates correct JSON schema with required arrays and objects" do
+      schema = TestToolWithRequiredEmbeds.input_schema()
+
+      assert schema["required"] == ["metadata", "tags"]
+      assert schema["properties"]["tags"]["type"] == "array"
+      assert schema["properties"]["metadata"]["type"] == "object"
+    end
+
+    test "validates required fields" do
+      assert {:error, _} = TestToolWithRequiredEmbeds.mcp_schema(%{})
+
+      params = %{
+        tags: [%{name: "env", value: "prod"}],
+        metadata: %{version: 1}
+      }
+
+      assert {:ok, ^params} = TestToolWithRequiredEmbeds.mcp_schema(params)
+    end
+  end
+end


### PR DESCRIPTION
This pull request introduces support for embedding complex nested fields in schemas within the `Hermes.Server.Component` module. It adds two new macros, `embeds_many` and `embeds_one`, along with corresponding tests to validate their functionality and ensure proper schema generation and input validation.

### Enhancements to schema definition:

* **Added `embeds_many` macro**: Enables defining fields that embed an array of objects, with options for marking them as required and providing descriptions.
* **Added `embeds_one` macro**: Enables defining fields that embed a single object, with similar options for required fields and descriptions.

### Code improvements:

* **Updated import list in `Hermes.Server.Component`**: Included `embeds_many` and `embeds_one` macros in the import list to make them available for use in schemas.
* **Refactored nested map handling**: Added a private function `__inject_transforms__/1` to clean and transform nested maps for embedded schemas.

### Testing additions:

* **Comprehensive tests for embedded fields**: Added a new test module `Hermes.Server.ComponentEmbedsTest` to validate the functionality of `embeds_many` and `embeds_one`. The tests cover JSON schema generation, input validation, and required field handling for both macros.