### PR TITLE
fix: correctly set supported versions for different transports

### DIFF
--- a/lib/hermes/protocol.ex
+++ b/lib/hermes/protocol.ex
@@ -78,8 +78,8 @@ defmodule Hermes.Protocol do
   Validates if a transport is compatible with a protocol version.
   """
   @spec validate_transport(version(), module()) :: :ok | {:error, Error.t()}
-  def validate_transport(version, transport_module) do
-    supported_versions = transport_module.supported_protocol_versions()
+  def validate_transport(version, transport) do
+    supported_versions = supported_transport_versions(transport)
 
     if version in supported_versions do
       :ok
@@ -87,9 +87,16 @@ defmodule Hermes.Protocol do
       {:error,
        Error.transport(:incompatible_transport, %{
          version: version,
-         transport: transport_module,
+         transport: transport,
          supported_versions: supported_versions
        })}
+    end
+  end
+
+  defp supported_transport_versions(transport) do
+    case transport.supported_protocol_versions() do
+      :all -> @supported_versions
+      [_ | _] = versions -> versions
     end
   end
 

--- a/lib/hermes/server/transport/stdio.ex
+++ b/lib/hermes/server/transport/stdio.ex
@@ -95,9 +95,7 @@ defmodule Hermes.Server.Transport.STDIO do
   end
 
   @impl Transport
-  def supported_protocol_versions do
-    ["2024-11-05", "2025-03-26"]
-  end
+  def supported_protocol_versions, do: :all
 
   @impl GenServer
   def init(opts) do

--- a/lib/hermes/server/transport/streamable_http.ex
+++ b/lib/hermes/server/transport/streamable_http.ex
@@ -125,9 +125,7 @@ defmodule Hermes.Server.Transport.StreamableHTTP do
   end
 
   @impl Transport
-  def supported_protocol_versions do
-    ["2024-11-05", "2025-03-26"]
-  end
+  def supported_protocol_versions, do: ["2025-03-26", "2025-06-18"]
 
   @doc """
   Registers an SSE handler process for a session.

--- a/lib/hermes/transport/behaviour.ex
+++ b/lib/hermes/transport/behaviour.ex
@@ -22,5 +22,5 @@ defmodule Hermes.Transport.Behaviour do
       iex> MyTransport.supported_protocol_versions()
       ["2024-11-05", "2025-03-26"]
   """
-  @callback supported_protocol_versions() :: [String.t()]
+  @callback supported_protocol_versions() :: [String.t()] | :all
 end

--- a/lib/hermes/transport/stdio.ex
+++ b/lib/hermes/transport/stdio.ex
@@ -83,9 +83,7 @@ defmodule Hermes.Transport.STDIO do
   end
 
   @impl Transport
-  def supported_protocol_versions do
-    ["2024-11-05", "2025-03-26"]
-  end
+  def supported_protocol_versions, do: :all
 
   @impl GenServer
   def init(%{} = opts) do

--- a/lib/hermes/transport/streamable_http.ex
+++ b/lib/hermes/transport/streamable_http.ex
@@ -77,7 +77,7 @@ defmodule Hermes.Transport.StreamableHTTP do
           | {:enable_sse, boolean()}
           | GenServer.option()
 
-  defschema :options_schema, %{
+  defschema(:options_schema, %{
     name: {{:custom, &Hermes.genserver_name/1}, {:default, __MODULE__}},
     client: {:required, Hermes.get_schema(:process_name)},
     base_url: {:required, {:string, {:transform, &URI.new!/1}}},
@@ -86,7 +86,7 @@ defmodule Hermes.Transport.StreamableHTTP do
     transport_opts: {:any, {:default, []}},
     http_options: {:any, {:default, []}},
     enable_sse: {:boolean, {:default, false}}
-  }
+  })
 
   @impl Transport
   @spec start_link(params_t) :: GenServer.on_start()
@@ -106,9 +106,7 @@ defmodule Hermes.Transport.StreamableHTTP do
   end
 
   @impl Transport
-  def supported_protocol_versions do
-    ["2025-03-26"]
-  end
+  def supported_protocol_versions, do: ["2025-03-26", "2025-06-18"]
 
   @impl GenServer
   def init(opts) do

--- a/lib/hermes/transport/websocket.ex
+++ b/lib/hermes/transport/websocket.ex
@@ -91,9 +91,7 @@ if Code.ensure_loaded?(:gun) do
     end
 
     @impl Transport
-    def supported_protocol_versions do
-      ["2024-11-05", "2025-03-26"]
-    end
+    def supported_protocol_versions, do: :all
 
     @impl GenServer
     def init(%{} = opts) do

--- a/test/support/mock_transport.ex
+++ b/test/support/mock_transport.ex
@@ -12,5 +12,5 @@ defmodule MockTransport do
   def shutdown(_), do: :ok
 
   @impl true
-  def supported_protocol_versions, do: ["2025-06-18", "2025-03-26", "2024-11-05"]
+  def supported_protocol_versions, do: :all
 end

--- a/test/support/stub_transport.ex
+++ b/test/support/stub_transport.ex
@@ -90,9 +90,7 @@ defmodule StubTransport do
   end
 
   @impl true
-  def supported_protocol_versions do
-    ["2024-11-05", "2025-03-26"]
-  end
+  def supported_protocol_versions, do: :all
 
   @impl true
   def init(state) do


### PR DESCRIPTION
This pull request refactors how protocol version compatibility is handled across transports in the Hermes system. It introduces a new mechanism for specifying supported protocol versions, updates the behavior definition, and modifies several transport modules to align with the new approach.

### Refactoring protocol version handling:

* [`lib/hermes/protocol.ex`](diffhunk://#diff-98232ed245d0a2546cad3d194c94fd8e637e46a66416b40a5d067ae1850522dbL81-R102): Added the `supported_transport_versions/1` private function to handle cases where a transport specifies `:all` as its supported protocol versions, mapping it to the global `@supported_versions`. Updated the `validate_transport/2` function to use this new mechanism.

### Updates to transport modules:

* [`lib/hermes/transport/behaviour.ex`](diffhunk://#diff-71dc0b3f96d79ae5f656538529828d6dbcc9c2cb2f58b5d938b51fdc06851cadL25-R25): Updated the `supported_protocol_versions/0` callback to allow transports to return either a list of strings or `:all`.
* `lib/hermes/server/transport/stdio.ex`, `lib/hermes/transport/stdio.ex`, `lib/hermes/transport/websocket.ex`, `test/support/mock_transport.ex`, `test/support/stub_transport.ex`: Modified the `supported_protocol_versions/0` implementations to return `:all` instead of hardcoded lists for certain transports. [[1]](diffhunk://#diff-61921887b952ce41ebfb436711dca9d7f8b7c6a9dfd56cc0c2a20baced77362fL98-R98) [[2]](diffhunk://#diff-6545e6cca647b52bd939e362d7a246724f0190d4eabbeb3cad9724a2f0c4a63cL86-R86) [[3]](diffhunk://#diff-c1dee42ccc6dfb67a6df853f41e6afb92bcf40f4abf0084d0a4f261da09a0ba4L94-R94) [[4]](diffhunk://#diff-ceaf02dc0afad3b8c01fbd0ee8194081ab1c0b5ce78f6e1fcbdf3b5ebb04fbbaL15-R15) [[5]](diffhunk://#diff-1d9b45a0670ea752f56967d81e40b4f9dd2870b0e71c863bb352bf6c94ea2995L93-R93)
* [`lib/hermes/server/transport/streamable_http.ex`](diffhunk://#diff-da9c9a7a019b46d51290734c0735d5901ec1f1ee58ee44dc8b68912164e90ba0L128-R128): Updated `supported_protocol_versions/0` to reflect new supported versions, adding "2025-06-18". [[1]](diffhunk://#diff-da9c9a7a019b46d51290734c0735d5901ec1f1ee58ee44dc8b68912164e90ba0L128-R128) [[2]](diffhunk://#diff-783726aa86a0f2e2c55f5aedce0e709b795bc7550f9b816eae300be91329bb75L109-R109)

### Code style improvements:

* [`lib/hermes/transport/streamable_http.ex`](diffhunk://#diff-783726aa86a0f2e2c55f5aedce0e709b795bc7550f9b816eae300be91329bb75L80-R80): Adjusted schema definitions to use parentheses for consistency in formatting. [[1]](diffhunk://#diff-783726aa86a0f2e2c55f5aedce0e709b795bc7550f9b816eae300be91329bb75L80-R80) [[2]](diffhunk://#diff-783726aa86a0f2e2c55f5aedce0e709b795bc7550f9b816eae300be91329bb75L89-R89)

These changes enhance flexibility in defining protocol compatibility, improve maintainability, and ensure consistency across the codebase.