### PR TITLE
fix: remove assign redact feature, simplify server state inspect

### DIFF
--- a/lib/hermes/server/session.ex
+++ b/lib/hermes/server/session.ex
@@ -140,3 +140,20 @@ defmodule Hermes.Server.Session do
     Agent.get(session, & &1.pending_requests)
   end
 end
+
+defimpl Inspect, for: Hermes.Server.Session do
+  import Inspect.Algebra
+
+  def inspect(session, opts) do
+    info = [
+      id: session.id,
+      initialized: session.initialized,
+      pending_requests: map_size(session.pending_requests)
+    ]
+
+    info = if session.protocol_version, do: [{:protocol_version, session.protocol_version} | info], else: info
+    info = if session.client_info, do: [{:client_info, session.client_info["name"] || "unknown"} | info], else: info
+
+    concat(["#Session<", to_doc(info, opts), ">"])
+  end
+end

--- a/pages/building-a-server.md
+++ b/pages/building-a-server.md
@@ -445,37 +445,6 @@ defmodule MyApp.ServerTest do
 end
 ```
 
-## Security Configuration
-
-### Sensitive Data Redaction
-
-Hermes automatically redacts sensitive internal data (like HTTP headers, environment variables) when logging errors or crashes. For your application's `assigns` data, you can configure custom redaction patterns:
-
-```elixir
-# In your config/config.exs or runtime.exs
-config :hermes_mcp,
-  MyApp.Server,
-  redact_patterns: [
-    "password",
-    "token",
-    "secret",
-    ~r/api[_-]?key/i,
-    ~r/auth/i
-  ]
-```
-
-Any assign key matching these patterns will be redacted as `[REDACTED]` in logs:
-
-```elixir
-# Original frame assigns
-%{api_key: "sk-123", username: "alice", password: "secret123"}
-
-# Appears in logs as
-%{api_key: "[REDACTED]", username: "alice", password: "[REDACTED]"}
-```
-
-This helps prevent accidental exposure of sensitive data in error logs or crash reports while maintaining debugging capabilities.
-
 ## What's Next?
 
 You've seen how to expose your Elixir application's capabilities to AI assistants. What patterns interest you most?


### PR DESCRIPTION
This pull request refactors the `Hermes.Server.Base` module to improve state formatting and logging while removing sensitive data redaction logic. Additionally, it introduces a custom `Inspect` implementation for `Hermes.Server.Session` and updates documentation to reflect these changes.

### Refactoring and state formatting improvements:

* [`lib/hermes/server/base.ex`](diffhunk://#diff-1146a134b004c3f80ca5063ac01c480f7a3364c39d4ce152f102e24db0f18673L306-R349): Replaced the `sanitize_state` function with `format_state`, which formats the server state for better readability and includes new helper functions like `format_pending_requests` and `format_sessions`. Removed sensitive data redaction logic, simplifying the codebase. [[1]](diffhunk://#diff-1146a134b004c3f80ca5063ac01c480f7a3364c39d4ce152f102e24db0f18673L306-R349) [[2]](diffhunk://#diff-1146a134b004c3f80ca5063ac01c480f7a3364c39d4ce152f102e24db0f18673L875-L958)

### Enhanced session inspection:

* [`lib/hermes/server/session.ex`](diffhunk://#diff-27f838a493dce5976cf8f302c1ee79c75aad6a508ed781266863b6c48e9404b2R143-R159): Added a custom `Inspect` implementation for `Hermes.Server.Session` to provide a concise and informative representation of session attributes, including `id`, `initialized`, `pending_requests`, and optional fields like `protocol_version` and `client_info`.

### Documentation updates:

* [`pages/building-a-server.md`](diffhunk://#diff-f112045ebd79df2630af0cea8f65b72717ea2a002e77f18afca2e2cf47be5c64L448-L478): Removed the "Sensitive Data Redaction" section, as the redaction logic has been eliminated from the codebase. Updated documentation to align with the refactored approach.

Release-As: 0.13.1