### PR TITLE
feat: propagating headers on requests

### DIFF
--- a/lib/hermes/client/base.ex
+++ b/lib/hermes/client/base.ex
@@ -1469,15 +1469,14 @@ defmodule Hermes.Client.Base do
     send_notification(state, "notifications/cancelled", params)
   end
 
-  # StreamableHTTP with headers
-  defp send_to_transport(%{layer: StreamableHTTP} = transport, data, headers) when not is_nil(headers) do
-    with {:error, reason} <-
-           StreamableHTTP.send_message_with_headers(transport.name, data, headers) do
+  defp send_to_transport(transport, data, headers) when not is_nil(headers) do
+    opts = [headers: headers]
+
+    with {:error, reason} <- transport.layer.send_message(transport.name, data, opts) do
       {:error, Error.transport(:send_failure, %{original_reason: reason})}
     end
   end
 
-  # Default case: no headers or different transport
   defp send_to_transport(transport, data, _headers) do
     send_to_transport(transport, data)
   end

--- a/lib/hermes/client/base.ex
+++ b/lib/hermes/client/base.ex
@@ -15,6 +15,7 @@ defmodule Hermes.Client.Base do
   alias Hermes.MCP.Response
   alias Hermes.Protocol
   alias Hermes.Telemetry
+  alias Hermes.Transport.StreamableHTTP
 
   require Message
 
@@ -81,7 +82,7 @@ defmodule Hermes.Client.Base do
              Hermes.Transport.STDIO
              | Hermes.Transport.SSE
              | Hermes.Transport.WebSocket
-             | Hermes.Transport.StreamableHTTP}
+             | StreamableHTTP}
             | {:name, GenServer.server()}
           )
 
@@ -325,6 +326,7 @@ defmodule Hermes.Client.Base do
     * `:progress` - Progress tracking options
       * `:token` - A unique token to track progress (string or integer)
       * `:callback` - A function to call when progress updates are received
+    * `:headers` - HTTP headers to send with this request (map, only for StreamableHTTP transport)
   """
   @spec call_tool(t, String.t(), map() | nil, keyword) ::
           {:ok, Response.t()} | {:error, Error.t()}
@@ -337,9 +339,11 @@ defmodule Hermes.Client.Base do
         method: "tools/call",
         params: params,
         progress_opts: Keyword.get(opts, :progress),
-        timeout: Keyword.get(opts, :timeout)
+        timeout: Keyword.get(opts, :timeout),
+        headers: Keyword.get(opts, :headers)
       })
 
+    dbg(operation)
     buffer_timeout = operation.timeout + to_timeout(second: 1)
     GenServer.call(client, {:operation, operation}, buffer_timeout)
   end
@@ -429,7 +433,7 @@ defmodule Hermes.Client.Base do
       ref = %{"type" => "ref/prompt", "name" => "code_review"}
       argument = %{"name" => "language", "value" => "py"}
       {:ok, response} = Hermes.Client.complete(client, ref, argument)
-      
+
       # Access the completion values
       values = get_in(Response.unwrap(response), ["completion", "values"])
   """
@@ -706,14 +710,14 @@ defmodule Hermes.Client.Base do
 
       MyClient.register_sampling_callback(fn params ->
         messages = params["messages"]
-        
+
         # Show UI for user approval
         case MyUI.approve_sampling(messages) do
           {:approved, edited_messages} ->
             # Call LLM with approved/edited messages
             response = MyLLM.generate(edited_messages, params["modelPreferences"])
             {:ok, response}
-            
+
           :rejected ->
             {:error, "User rejected sampling request"}
         end
@@ -799,7 +803,7 @@ defmodule Hermes.Client.Base do
          {request_id, updated_state} =
            State.add_request_from_operation(state, operation, from),
          {:ok, request_data} <- encode_request(method, params_with_token, request_id),
-         :ok <- send_to_transport(state.transport, request_data) do
+         :ok <- send_to_transport_with_headers(state.transport, request_data, operation.headers) do
       Telemetry.execute(
         Telemetry.event_client_request(),
         %{system_time: System.system_time()},
@@ -1464,6 +1468,19 @@ defmodule Hermes.Client.Base do
     }
 
     send_notification(state, "notifications/cancelled", params)
+  end
+
+  defp send_to_transport_with_headers(transport, data, headers) do
+    if is_nil(headers) or transport.layer != StreamableHTTP do
+      # No headers provided or not using StreamableHTTP, use regular send
+      send_to_transport(transport, data)
+    else
+      # Use StreamableHTTP with headers
+      with {:error, reason} <-
+             StreamableHTTP.send_message_with_headers(transport.name, data, headers) do
+        {:error, Error.transport(:send_failure, %{original_reason: reason})}
+      end
+    end
   end
 
   defp send_to_transport(transport, data) do

--- a/lib/hermes/client/base.ex
+++ b/lib/hermes/client/base.ex
@@ -1471,7 +1471,7 @@ defmodule Hermes.Client.Base do
   # StreamableHTTP with headers
   defp send_to_transport(%{layer: StreamableHTTP} = transport, data, headers) when not is_nil(headers) do
     with {:error, reason} <-
-           StreamableHTTP.send_message_with_headers(transport.name, data, headers) do
+           Hermes.Transport.StreamableHTTP.send_message_with_headers(transport.name, data, headers) do
       {:error, Error.transport(:send_failure, %{original_reason: reason})}
     end
   end

--- a/lib/hermes/client/base.ex
+++ b/lib/hermes/client/base.ex
@@ -15,6 +15,7 @@ defmodule Hermes.Client.Base do
   alias Hermes.MCP.Response
   alias Hermes.Protocol
   alias Hermes.Telemetry
+  alias Hermes.Transport.StreamableHTTP
 
   require Message
 
@@ -81,7 +82,7 @@ defmodule Hermes.Client.Base do
              Hermes.Transport.STDIO
              | Hermes.Transport.SSE
              | Hermes.Transport.WebSocket
-             | Hermes.Transport.StreamableHTTP}
+             | StreamableHTTP}
             | {:name, GenServer.server()}
           )
 

--- a/lib/hermes/client/base.ex
+++ b/lib/hermes/client/base.ex
@@ -1472,7 +1472,7 @@ defmodule Hermes.Client.Base do
   # StreamableHTTP with headers
   defp send_to_transport(%{layer: StreamableHTTP} = transport, data, headers) when not is_nil(headers) do
     with {:error, reason} <-
-           Hermes.Transport.StreamableHTTP.send_message_with_headers(transport.name, data, headers) do
+           StreamableHTTP.send_message_with_headers(transport.name, data, headers) do
       {:error, Error.transport(:send_failure, %{original_reason: reason})}
     end
   end

--- a/lib/hermes/client/base.ex
+++ b/lib/hermes/client/base.ex
@@ -15,7 +15,6 @@ defmodule Hermes.Client.Base do
   alias Hermes.MCP.Response
   alias Hermes.Protocol
   alias Hermes.Telemetry
-  alias Hermes.Transport.StreamableHTTP
 
   require Message
 
@@ -82,7 +81,7 @@ defmodule Hermes.Client.Base do
              Hermes.Transport.STDIO
              | Hermes.Transport.SSE
              | Hermes.Transport.WebSocket
-             | StreamableHTTP}
+             | Hermes.Transport.StreamableHTTP}
             | {:name, GenServer.server()}
           )
 
@@ -343,7 +342,6 @@ defmodule Hermes.Client.Base do
         headers: Keyword.get(opts, :headers)
       })
 
-    dbg(operation)
     buffer_timeout = operation.timeout + to_timeout(second: 1)
     GenServer.call(client, {:operation, operation}, buffer_timeout)
   end

--- a/lib/hermes/client/operation.ex
+++ b/lib/hermes/client/operation.ex
@@ -20,14 +20,16 @@ defmodule Hermes.Client.Operation do
           method: String.t(),
           params: map(),
           progress_opts: progress_options() | nil,
-          timeout: pos_integer()
+          timeout: pos_integer(),
+          headers: map() | nil
         }
 
   defstruct [
     :method,
     params: %{},
     progress_opts: [],
-    timeout: @default_timeout
+    timeout: @default_timeout,
+    headers: nil
   ]
 
   @doc """
@@ -40,19 +42,22 @@ defmodule Hermes.Client.Operation do
       * `:params` - The parameters to send to the server (required)
       * `:progress_opts` - Progress tracking options (optional)
       * `:timeout` - The timeout for this operation in milliseconds (optional, defaults to 30s)
+      * `:headers` - HTTP headers to send with this request (optional, only for StreamableHTTP transport)
   """
   @spec new(%{
           required(:method) => String.t(),
           optional(:params) => map(),
           optional(:progress_opts) => progress_options() | nil,
-          optional(:timeout) => pos_integer()
+          optional(:timeout) => pos_integer(),
+          optional(:headers) => map()
         }) :: t()
   def new(%{method: method} = attrs) do
     %__MODULE__{
       method: method,
       params: Map.get(attrs, :params) || %{},
       progress_opts: Map.get(attrs, :progress_opts),
-      timeout: Map.get(attrs, :timeout) || @default_timeout
+      timeout: Map.get(attrs, :timeout) || @default_timeout,
+      headers: Map.get(attrs, :headers)
     }
   end
 end

--- a/lib/hermes/transport/streamable_http.ex
+++ b/lib/hermes/transport/streamable_http.ex
@@ -97,7 +97,7 @@ defmodule Hermes.Transport.StreamableHTTP do
 
   @impl Transport
   def send_message(pid \\ __MODULE__, message) when is_binary(message) do
-    GenServer.call(pid, {:send, message})
+    GenServer.call(pid, {:send, message}, 15_000)
   end
 
   @doc """
@@ -119,7 +119,7 @@ defmodule Hermes.Transport.StreamableHTTP do
   """
   @spec send_message_with_headers(t(), Transport.message(), map()) :: :ok | {:error, term()}
   def send_message_with_headers(pid \\ __MODULE__, message, headers) when is_binary(message) and is_map(headers) do
-    GenServer.call(pid, {:send_with_headers, message, headers})
+    GenServer.call(pid, {:send_with_headers, message, headers}, 15_000)
   end
 
   @impl Transport


### PR DESCRIPTION
## Problem

Currently we are not propagating / accepting headers for StreamableHttp transport

## Solution

Implementation of header optional param

## Rationale

Will be handled only for StreamableHTTP for now.
