### PR TITLE
feat: propagating opts from client.base

### DIFF
--- a/lib/hermes/server/transport/sse.ex
+++ b/lib/hermes/server/transport/sse.ex
@@ -131,8 +131,8 @@ defmodule Hermes.Server.Transport.SSE do
     * `{:error, reason}` otherwise
   """
   @impl Transport
-  @spec send_message(GenServer.server(), binary()) :: :ok | {:error, term()}
-  def send_message(transport, message) when is_binary(message) do
+  @spec send_message(GenServer.server(), binary(), keyword()) :: :ok | {:error, term()}
+  def send_message(transport, message, _opts \\ []) when is_binary(message) do
     GenServer.call(transport, {:send_message, message})
   end
 

--- a/lib/hermes/server/transport/stdio.ex
+++ b/lib/hermes/server/transport/stdio.ex
@@ -78,7 +78,7 @@ defmodule Hermes.Server.Transport.STDIO do
   """
   @impl Transport
   @spec send_message(GenServer.server(), binary(), keyword()) :: :ok | {:error, term()}
-  def send_message(transport, message, _opts) when is_binary(message) do
+  def send_message(transport, message, _opts \\ []) when is_binary(message) do
     GenServer.cast(transport, {:send, message})
   end
 

--- a/lib/hermes/server/transport/stdio.ex
+++ b/lib/hermes/server/transport/stdio.ex
@@ -77,8 +77,8 @@ defmodule Hermes.Server.Transport.STDIO do
     * `{:error, reason}` otherwise
   """
   @impl Transport
-  @spec send_message(GenServer.server(), binary()) :: :ok | {:error, term()}
-  def send_message(transport, message) when is_binary(message) do
+  @spec send_message(GenServer.server(), binary(), keyword()) :: :ok | {:error, term()}
+  def send_message(transport, message, _opts) when is_binary(message) do
     GenServer.cast(transport, {:send, message})
   end
 
@@ -262,7 +262,7 @@ defmodule Hermes.Server.Transport.STDIO do
     else
       case GenServer.call(server, {:request, message, "stdio", context}, timeout) do
         {:ok, response} when is_binary(response) ->
-          send_message(self(), response)
+          send_message(self(), response, [])
 
         {:error, reason} ->
           Logging.transport_event("server_error", %{reason: reason}, level: :error)

--- a/lib/hermes/server/transport/streamable_http.ex
+++ b/lib/hermes/server/transport/streamable_http.ex
@@ -105,8 +105,8 @@ defmodule Hermes.Server.Transport.StreamableHTTP do
     * `{:error, reason}` otherwise
   """
   @impl Transport
-  @spec send_message(GenServer.server(), binary()) :: :ok | {:error, term()}
-  def send_message(transport, message) when is_binary(message) do
+  @spec send_message(GenServer.server(), binary(), keyword()) :: :ok | {:error, term()}
+  def send_message(transport, message, _opts) when is_binary(message) do
     GenServer.call(transport, {:send_message, message})
   end
 

--- a/lib/hermes/server/transport/streamable_http.ex
+++ b/lib/hermes/server/transport/streamable_http.ex
@@ -106,7 +106,7 @@ defmodule Hermes.Server.Transport.StreamableHTTP do
   """
   @impl Transport
   @spec send_message(GenServer.server(), binary(), keyword()) :: :ok | {:error, term()}
-  def send_message(transport, message, _opts) when is_binary(message) do
+  def send_message(transport, message, _opts \\ []) when is_binary(message) do
     GenServer.call(transport, {:send_message, message})
   end
 

--- a/lib/hermes/transport/behaviour.ex
+++ b/lib/hermes/transport/behaviour.ex
@@ -11,7 +11,7 @@ defmodule Hermes.Transport.Behaviour do
   @type reason :: term() | Error.t()
 
   @callback start_link(keyword()) :: GenServer.on_start()
-  @callback send_message(t(), message()) :: :ok | {:error, reason()}
+  @callback send_message(t(), message(), keyword()) :: :ok | {:error, reason()}
   @callback shutdown(t()) :: :ok | {:error, reason()}
 
   @doc """

--- a/lib/hermes/transport/sse.ex
+++ b/lib/hermes/transport/sse.ex
@@ -101,7 +101,7 @@ defmodule Hermes.Transport.SSE do
   end
 
   @impl Transport
-  def send_message(pid, message, _opts) when is_binary(message) do
+  def send_message(pid, message, _opts \\ []) when is_binary(message) do
     GenServer.call(pid, {:send, message})
   end
 

--- a/lib/hermes/transport/sse.ex
+++ b/lib/hermes/transport/sse.ex
@@ -101,7 +101,7 @@ defmodule Hermes.Transport.SSE do
   end
 
   @impl Transport
-  def send_message(pid, message) when is_binary(message) do
+  def send_message(pid, message, _opts) when is_binary(message) do
     GenServer.call(pid, {:send, message})
   end
 

--- a/lib/hermes/transport/stdio.ex
+++ b/lib/hermes/transport/stdio.ex
@@ -73,7 +73,7 @@ defmodule Hermes.Transport.STDIO do
   end
 
   @impl Transport
-  def send_message(pid \\ __MODULE__, message) when is_binary(message) do
+  def send_message(pid \\ __MODULE__, message, _opts) when is_binary(message) do
     GenServer.call(pid, {:send, message})
   end
 

--- a/lib/hermes/transport/stdio.ex
+++ b/lib/hermes/transport/stdio.ex
@@ -73,7 +73,7 @@ defmodule Hermes.Transport.STDIO do
   end
 
   @impl Transport
-  def send_message(pid \\ __MODULE__, message, _opts) when is_binary(message) do
+  def send_message(pid \\ __MODULE__, message, _opts \\ []) when is_binary(message) do
     GenServer.call(pid, {:send, message})
   end
 

--- a/lib/hermes/transport/streamable_http.ex
+++ b/lib/hermes/transport/streamable_http.ex
@@ -52,6 +52,8 @@ defmodule Hermes.Transport.StreamableHTTP do
   alias Hermes.Telemetry
   alias Hermes.Transport.Behaviour, as: Transport
 
+  @default_timeout 15_000
+
   @type t :: GenServer.server()
   @type params_t :: Enumerable.t(option)
 
@@ -97,7 +99,8 @@ defmodule Hermes.Transport.StreamableHTTP do
 
   @impl Transport
   def send_message(pid \\ __MODULE__, message, opts \\ []) when is_binary(message) do
-    GenServer.call(pid, {:send, message, opts})
+    timeout = Keyword.get(opts, :timeout, @default_timeout)
+    GenServer.call(pid, {:send, message, opts}, timeout)
   end
 
   @impl Transport

--- a/lib/hermes/transport/websocket.ex
+++ b/lib/hermes/transport/websocket.ex
@@ -81,7 +81,7 @@ if Code.ensure_loaded?(:gun) do
     end
 
     @impl Transport
-    def send_message(pid, message) when is_binary(message) do
+    def send_message(pid, message, _opts) when is_binary(message) do
       GenServer.call(pid, {:send, message})
     end
 

--- a/lib/hermes/transport/websocket.ex
+++ b/lib/hermes/transport/websocket.ex
@@ -81,7 +81,7 @@ if Code.ensure_loaded?(:gun) do
     end
 
     @impl Transport
-    def send_message(pid, message, _opts) when is_binary(message) do
+    def send_message(pid, message, _opts \\ []) when is_binary(message) do
       GenServer.call(pid, {:send, message})
     end
 

--- a/test/hermes/client/base_test.exs
+++ b/test/hermes/client/base_test.exs
@@ -18,7 +18,7 @@ defmodule Hermes.Client.BaseTest do
 
   describe "start_link/1" do
     test "starts the client with proper initialization" do
-      expect(Hermes.MockTransport, :send_message, fn _, message ->
+      expect(Hermes.MockTransport, :send_message, fn _, message, _opts ->
         assert String.contains?(message, "initialize")
         assert String.contains?(message, "protocolVersion")
         assert String.contains?(message, "capabilities")
@@ -46,7 +46,7 @@ defmodule Hermes.Client.BaseTest do
     setup :initialized_client
 
     test "ping sends correct request", %{client: client} do
-      expect(Hermes.MockTransport, :send_message, fn _, message ->
+      expect(Hermes.MockTransport, :send_message, fn _, message, _opts ->
         decoded = JSON.decode!(message)
         assert decoded["method"] == "ping"
         assert decoded["params"] == %{}
@@ -69,7 +69,7 @@ defmodule Hermes.Client.BaseTest do
     end
 
     test "list_resources sends correct request", %{client: client} do
-      expect(Hermes.MockTransport, :send_message, fn _, message ->
+      expect(Hermes.MockTransport, :send_message, fn _, message, _opts ->
         decoded = JSON.decode!(message)
         assert decoded["method"] == "resources/list"
         assert decoded["params"] == %{}
@@ -99,7 +99,7 @@ defmodule Hermes.Client.BaseTest do
     end
 
     test "list_resources with cursor", %{client: client} do
-      expect(Hermes.MockTransport, :send_message, fn _, message ->
+      expect(Hermes.MockTransport, :send_message, fn _, message, _opts ->
         decoded = JSON.decode!(message)
         assert decoded["method"] == "resources/list"
         assert decoded["params"] == %{"cursor" => "next-page"}
@@ -132,7 +132,7 @@ defmodule Hermes.Client.BaseTest do
     end
 
     test "read_resource sends correct request", %{client: client} do
-      expect(Hermes.MockTransport, :send_message, fn _, message ->
+      expect(Hermes.MockTransport, :send_message, fn _, message, _opts ->
         decoded = JSON.decode!(message)
         assert decoded["method"] == "resources/read"
         assert decoded["params"] == %{"uri" => "test://uri"}
@@ -162,7 +162,7 @@ defmodule Hermes.Client.BaseTest do
     end
 
     test "list_prompts sends correct request", %{client: client} do
-      expect(Hermes.MockTransport, :send_message, fn _, message ->
+      expect(Hermes.MockTransport, :send_message, fn _, message, _opts ->
         decoded = JSON.decode!(message)
         assert decoded["method"] == "prompts/list"
         assert decoded["params"] == %{}
@@ -192,7 +192,7 @@ defmodule Hermes.Client.BaseTest do
     end
 
     test "get_prompt sends correct request", %{client: client} do
-      expect(Hermes.MockTransport, :send_message, fn _, message ->
+      expect(Hermes.MockTransport, :send_message, fn _, message, _opts ->
         decoded = JSON.decode!(message)
         assert decoded["method"] == "prompts/get"
 
@@ -232,7 +232,7 @@ defmodule Hermes.Client.BaseTest do
     end
 
     test "list_tools sends correct request", %{client: client} do
-      expect(Hermes.MockTransport, :send_message, fn _, message ->
+      expect(Hermes.MockTransport, :send_message, fn _, message, _opts ->
         decoded = JSON.decode!(message)
         assert decoded["method"] == "tools/list"
         assert decoded["params"] == %{}
@@ -262,7 +262,7 @@ defmodule Hermes.Client.BaseTest do
     end
 
     test "call_tool sends correct request", %{client: client} do
-      expect(Hermes.MockTransport, :send_message, fn _, message ->
+      expect(Hermes.MockTransport, :send_message, fn _, message, _opts ->
         decoded = JSON.decode!(message)
         assert decoded["method"] == "tools/call"
 
@@ -300,7 +300,7 @@ defmodule Hermes.Client.BaseTest do
     end
 
     test "handles domain error responses as {:ok, response}", %{client: client} do
-      expect(Hermes.MockTransport, :send_message, fn _, message ->
+      expect(Hermes.MockTransport, :send_message, fn _, message, _opts ->
         decoded = JSON.decode!(message)
         assert decoded["method"] == "tools/call"
 
@@ -346,7 +346,7 @@ defmodule Hermes.Client.BaseTest do
     setup :initialized_client
 
     test "ping sends correct request since it is always supported", %{client: client} do
-      expect(Hermes.MockTransport, :send_message, fn _, message ->
+      expect(Hermes.MockTransport, :send_message, fn _, message, _opts ->
         decoded = JSON.decode!(message)
         assert decoded["method"] == "ping"
         assert decoded["params"] == %{}
@@ -381,7 +381,7 @@ defmodule Hermes.Client.BaseTest do
     setup :initialized_client
 
     test "handles error response", %{client: client} do
-      expect(Hermes.MockTransport, :send_message, fn _, message ->
+      expect(Hermes.MockTransport, :send_message, fn _, message, _opts ->
         decoded = JSON.decode!(message)
         assert decoded["method"] == "ping"
         :ok
@@ -404,7 +404,7 @@ defmodule Hermes.Client.BaseTest do
     end
 
     test "handles transport error", %{client: client} do
-      expect(Hermes.MockTransport, :send_message, fn _, _message ->
+      expect(Hermes.MockTransport, :send_message, fn _, _message, _opts ->
         {:error, :connection_closed}
       end)
 
@@ -416,7 +416,7 @@ defmodule Hermes.Client.BaseTest do
 
   describe "capability management" do
     test "merge_capabilities correctly merges capabilities" do
-      expect(Hermes.MockTransport, :send_message, fn _, _message -> :ok end)
+      expect(Hermes.MockTransport, :send_message, fn _, _message, _opts -> :ok end)
 
       client =
         start_supervised!(
@@ -512,7 +512,7 @@ defmodule Hermes.Client.BaseTest do
     test "request with progress token includes it in params", %{client: client} do
       progress_token = "request_token_test"
 
-      expect(Hermes.MockTransport, :send_message, fn _, message ->
+      expect(Hermes.MockTransport, :send_message, fn _, message, _opts ->
         decoded = JSON.decode!(message)
         assert decoded["method"] == "resources/list"
 
@@ -564,7 +564,7 @@ defmodule Hermes.Client.BaseTest do
          }
 
     test "set_log_level sends the correct request", %{client: client} do
-      expect(Hermes.MockTransport, :send_message, fn _, message ->
+      expect(Hermes.MockTransport, :send_message, fn _, message, _opts ->
         decoded = JSON.decode!(message)
         assert decoded["method"] == "logging/setLevel"
         assert decoded["params"]["level"] == "info"
@@ -596,7 +596,7 @@ defmodule Hermes.Client.BaseTest do
       ref = %{"type" => "ref/prompt", "name" => "code_review"}
       argument = %{"name" => "language", "value" => "py"}
 
-      expect(Hermes.MockTransport, :send_message, fn _, message ->
+      expect(Hermes.MockTransport, :send_message, fn _, message, _opts ->
         decoded = JSON.decode!(message)
         assert decoded["method"] == "completion/complete"
         assert decoded["params"]["ref"]["type"] == "ref/prompt"
@@ -639,7 +639,7 @@ defmodule Hermes.Client.BaseTest do
       ref = %{"type" => "ref/resource", "uri" => "file:///path/to/file.txt"}
       argument = %{"name" => "encoding", "value" => "ut"}
 
-      expect(Hermes.MockTransport, :send_message, fn _, message ->
+      expect(Hermes.MockTransport, :send_message, fn _, message, _opts ->
         decoded = JSON.decode!(message)
         assert decoded["method"] == "completion/complete"
         assert decoded["params"]["ref"]["type"] == "ref/resource"
@@ -708,14 +708,14 @@ defmodule Hermes.Client.BaseTest do
     test "sends initialized notification after init" do
       Hermes.MockTransport
       # the handle_continue
-      |> expect(:send_message, fn _, message ->
+      |> expect(:send_message, fn _, message, _opts ->
         decoded = JSON.decode!(message)
         assert decoded["method"] == "initialize"
         assert decoded["jsonrpc"] == "2.0"
         :ok
       end)
       # the send_notification
-      |> expect(:send_message, fn _, message ->
+      |> expect(:send_message, fn _, message, _opts ->
         decoded = JSON.decode!(message)
         assert decoded["method"] == "notifications/initialized"
         :ok
@@ -745,7 +745,7 @@ defmodule Hermes.Client.BaseTest do
     setup :initialized_client
 
     test "handles cancelled notification from server", %{client: client} do
-      expect(Hermes.MockTransport, :send_message, fn _, message ->
+      expect(Hermes.MockTransport, :send_message, fn _, message, _opts ->
         decoded = JSON.decode!(message)
         assert decoded["method"] == "tools/call"
         :ok
@@ -773,7 +773,7 @@ defmodule Hermes.Client.BaseTest do
     end
 
     test "client can cancel a request", %{client: client} do
-      expect(Hermes.MockTransport, :send_message, fn _, message ->
+      expect(Hermes.MockTransport, :send_message, fn _, message, _opts ->
         decoded = JSON.decode!(message)
         assert decoded["method"] == "resources/list"
         :ok
@@ -786,7 +786,7 @@ defmodule Hermes.Client.BaseTest do
       request_id = get_request_id(client, "resources/list")
       assert request_id != nil
 
-      expect(Hermes.MockTransport, :send_message, fn _, message ->
+      expect(Hermes.MockTransport, :send_message, fn _, message, _opts ->
         decoded = JSON.decode!(message)
         assert decoded["method"] == "notifications/cancelled"
         assert decoded["params"]["requestId"] == request_id
@@ -817,7 +817,7 @@ defmodule Hermes.Client.BaseTest do
     end
 
     test "cancel_all_requests cancels all pending requests", %{client: client} do
-      expect(Hermes.MockTransport, :send_message, 2, fn _, message ->
+      expect(Hermes.MockTransport, :send_message, 2, fn _, message, _opts ->
         decoded = JSON.decode!(message)
         assert decoded["method"] in ["resources/list", "tools/list"]
         :ok
@@ -832,7 +832,7 @@ defmodule Hermes.Client.BaseTest do
       pending_count = map_size(state.pending_requests)
       assert pending_count == 2
 
-      expect(Hermes.MockTransport, :send_message, 2, fn _, message ->
+      expect(Hermes.MockTransport, :send_message, 2, fn _, message, _opts ->
         decoded = JSON.decode!(message)
         assert decoded["method"] == "notifications/cancelled"
         assert decoded["params"]["reason"] == "batch cancellation"
@@ -857,13 +857,13 @@ defmodule Hermes.Client.BaseTest do
     test "request timeout sends cancellation notification", %{client: client} do
       test_timeout = 50
 
-      expect(Hermes.MockTransport, :send_message, fn _, message ->
+      expect(Hermes.MockTransport, :send_message, fn _, message, _opts ->
         decoded = JSON.decode!(message)
         assert decoded["method"] == "resources/list"
         :ok
       end)
 
-      expect(Hermes.MockTransport, :send_message, fn _, message ->
+      expect(Hermes.MockTransport, :send_message, fn _, message, _opts ->
         decoded = JSON.decode!(message)
         assert decoded["method"] == "notifications/cancelled"
         assert decoded["params"]["reason"] == "timeout"
@@ -888,14 +888,14 @@ defmodule Hermes.Client.BaseTest do
          %{client: client} do
       test_timeout = 50
 
-      expect(Hermes.MockTransport, :send_message, fn _, message ->
+      expect(Hermes.MockTransport, :send_message, fn _, message, _opts ->
         decoded = JSON.decode!(message)
         assert decoded["method"] == "resources/list"
         Process.sleep(test_timeout + 10)
         :ok
       end)
 
-      expect(Hermes.MockTransport, :send_message, fn _, _ -> :ok end)
+      expect(Hermes.MockTransport, :send_message, fn _, _, _opts -> :ok end)
 
       Process.flag(:trap_exit, true)
 
@@ -912,13 +912,13 @@ defmodule Hermes.Client.BaseTest do
     end
 
     test "client.close sends cancellation for pending requests", %{client: client} do
-      expect(Hermes.MockTransport, :send_message, fn _, message ->
+      expect(Hermes.MockTransport, :send_message, fn _, message, _opts ->
         decoded = JSON.decode!(message)
         assert decoded["method"] == "resources/list"
         :ok
       end)
 
-      expect(Hermes.MockTransport, :send_message, fn _, message ->
+      expect(Hermes.MockTransport, :send_message, fn _, message, _opts ->
         decoded = JSON.decode!(message)
         assert decoded["method"] == "notifications/cancelled"
         assert decoded["params"]["reason"] == "client closed"
@@ -1069,7 +1069,7 @@ defmodule Hermes.Client.BaseTest do
 
       request_id = "server_req_123"
 
-      expect(Hermes.MockTransport, :send_message, fn _, message ->
+      expect(Hermes.MockTransport, :send_message, fn _, message, _opts ->
         decoded = JSON.decode!(message)
         assert decoded["jsonrpc"] == "2.0"
         assert decoded["id"] == request_id
@@ -1151,7 +1151,7 @@ defmodule Hermes.Client.BaseTest do
         "modelPreferences" => %{}
       }
 
-      expect(Hermes.MockTransport, :send_message, fn _, message ->
+      expect(Hermes.MockTransport, :send_message, fn _, message, _opts ->
         decoded = JSON.decode!(message)
         assert decoded["jsonrpc"] == "2.0"
         assert decoded["id"] == request_id
@@ -1188,7 +1188,7 @@ defmodule Hermes.Client.BaseTest do
         "modelPreferences" => %{}
       }
 
-      expect(Hermes.MockTransport, :send_message, fn _, message ->
+      expect(Hermes.MockTransport, :send_message, fn _, message, _opts ->
         decoded = JSON.decode!(message)
         assert decoded["jsonrpc"] == "2.0"
         assert decoded["id"] == request_id
@@ -1226,7 +1226,7 @@ defmodule Hermes.Client.BaseTest do
       request_id = "server_sampling_req_789"
       params = %{"messages" => [], "modelPreferences" => %{}}
 
-      expect(Hermes.MockTransport, :send_message, fn _, message ->
+      expect(Hermes.MockTransport, :send_message, fn _, message, _opts ->
         decoded = JSON.decode!(message)
         assert decoded["jsonrpc"] == "2.0"
         assert decoded["id"] == request_id
@@ -1264,7 +1264,7 @@ defmodule Hermes.Client.BaseTest do
       request_id = "server_sampling_req_999"
       params = %{"messages" => [], "modelPreferences" => %{}}
 
-      expect(Hermes.MockTransport, :send_message, fn _, message ->
+      expect(Hermes.MockTransport, :send_message, fn _, message, _opts ->
         decoded = JSON.decode!(message)
         assert decoded["jsonrpc"] == "2.0"
         assert decoded["id"] == request_id
@@ -1295,7 +1295,7 @@ defmodule Hermes.Client.BaseTest do
 
     @tag client_capabilities: %{"roots" => %{"listChanged" => true}}
     test "sends notification when adding a root", %{client: client} do
-      expect(Hermes.MockTransport, :send_message, fn _, message ->
+      expect(Hermes.MockTransport, :send_message, fn _, message, _opts ->
         decoded = JSON.decode!(message)
         assert decoded["jsonrpc"] == "2.0"
         assert decoded["method"] == "notifications/roots/list_changed"
@@ -1318,7 +1318,7 @@ defmodule Hermes.Client.BaseTest do
 
       Process.sleep(50)
 
-      expect(Hermes.MockTransport, :send_message, fn _, message ->
+      expect(Hermes.MockTransport, :send_message, fn _, message, _opts ->
         decoded = JSON.decode!(message)
         assert decoded["jsonrpc"] == "2.0"
         assert decoded["method"] == "notifications/roots/list_changed"
@@ -1350,7 +1350,7 @@ defmodule Hermes.Client.BaseTest do
 
       Process.sleep(50)
 
-      expect(Hermes.MockTransport, :send_message, fn _, message ->
+      expect(Hermes.MockTransport, :send_message, fn _, message, _opts ->
         decoded = JSON.decode!(message)
         assert decoded["jsonrpc"] == "2.0"
         assert decoded["method"] == "notifications/roots/list_changed"
@@ -1379,7 +1379,7 @@ defmodule Hermes.Client.BaseTest do
     setup :initialized_client
 
     test "handles tools with complex outputSchema", %{client: client} do
-      expect(Hermes.MockTransport, :send_message, fn _, _ -> :ok end)
+      expect(Hermes.MockTransport, :send_message, fn _, _, _opts -> :ok end)
 
       task = Task.async(fn -> Hermes.Client.Base.list_tools(client) end)
       Process.sleep(50)

--- a/test/hermes/server/transport/sse_test.exs
+++ b/test/hermes/server/transport/sse_test.exs
@@ -126,7 +126,7 @@ defmodule Hermes.Server.Transport.SSETest do
       assert_receive :registered, 1000
 
       message = "broadcast message"
-      assert :ok = SSE.send_message(transport, message)
+      assert :ok = SSE.send_message(transport, message, [])
 
       # Both handlers should receive the message
       assert_receive {:sse_message, ^message}

--- a/test/hermes/server/transport/stdio_test.exs
+++ b/test/hermes/server/transport/stdio_test.exs
@@ -32,7 +32,7 @@ defmodule Hermes.Server.Transport.STDIOTest do
       message = "test message"
 
       assert capture_io(pid, fn ->
-               assert :ok = STDIO.send_message(pid, message)
+               assert :ok = STDIO.send_message(pid, message, [])
                Process.sleep(50)
              end) =~ "test message"
 

--- a/test/hermes/server/transport/streamable_http_test.exs
+++ b/test/hermes/server/transport/streamable_http_test.exs
@@ -115,7 +115,7 @@ defmodule Hermes.Server.Transport.StreamableHTTPTest do
 
     test "send_message/2 works", %{transport: transport} do
       message = "test message"
-      assert :ok = StreamableHTTP.send_message(transport, message)
+      assert :ok = StreamableHTTP.send_message(transport, message, [])
     end
 
     test "shutdown/1 gracefully shuts down", %{transport: transport} do

--- a/test/hermes/transport/sse_test.exs
+++ b/test/hermes/transport/sse_test.exs
@@ -131,7 +131,7 @@ defmodule Hermes.Transport.SSETest do
       {:ok, ping_message} =
         Message.encode_request(%{"method" => "ping", "params" => %{}}, "1")
 
-      assert :ok = SSE.send_message(transport, ping_message)
+      assert :ok = SSE.send_message(transport, ping_message, [])
 
       # Give time for the response to come back
       Process.sleep(100)
@@ -168,7 +168,7 @@ defmodule Hermes.Transport.SSETest do
       Process.sleep(100)
 
       # Try to send a message without having an endpoint
-      assert {:error, :not_connected} = SSE.send_message(transport, "test message")
+      assert {:error, :not_connected} = SSE.send_message(transport, "test message", [])
 
       # Clean up
       SSE.shutdown(transport)
@@ -222,7 +222,7 @@ defmodule Hermes.Transport.SSETest do
 
       # Send a message and check for error response
       assert {:error, {:http_error, 500, "Internal Server Error"}} =
-               SSE.send_message(transport, "test message")
+               SSE.send_message(transport, "test message", [])
 
       # Clean up
       SSE.shutdown(transport)
@@ -380,7 +380,7 @@ defmodule Hermes.Transport.SSETest do
 
       transport_state = :sys.get_state(transport)
       assert transport_state.message_url != nil
-      assert :ok = SSE.send_message(transport, "test message")
+      assert :ok = SSE.send_message(transport, "test message", [])
 
       SSE.shutdown(transport)
       StubClient.clear_messages()
@@ -420,7 +420,7 @@ defmodule Hermes.Transport.SSETest do
 
       transport_state = :sys.get_state(transport)
       assert transport_state.message_url == "#{server_url}/messages/123"
-      assert :ok = SSE.send_message(transport, "test message")
+      assert :ok = SSE.send_message(transport, "test message", [])
 
       SSE.shutdown(transport)
       StubClient.clear_messages()
@@ -494,7 +494,7 @@ defmodule Hermes.Transport.SSETest do
       transport_state = :sys.get_state(transport)
       assert transport_state.message_url == "#{server_url}/messages/123"
       assert not String.contains?(transport_state.message_url, "/mcp/mcp/")
-      assert :ok = SSE.send_message(transport, "test message")
+      assert :ok = SSE.send_message(transport, "test message", [])
 
       SSE.shutdown(transport)
       StubClient.clear_messages()

--- a/test/hermes/transport/stdio_test.exs
+++ b/test/hermes/transport/stdio_test.exs
@@ -57,7 +57,7 @@ defmodule Hermes.Transport.STDIOTest do
     end
 
     test "sends message successfully", %{transport_pid: pid} do
-      assert :ok = STDIO.send_message(pid, "test message")
+      assert :ok = STDIO.send_message(pid, "test message", [])
     end
   end
 
@@ -80,7 +80,7 @@ defmodule Hermes.Transport.STDIOTest do
     test "forwards data to client", %{transport_pid: pid} do
       :ok = StubClient.clear_messages()
 
-      STDIO.send_message(pid, "echo test\n")
+      STDIO.send_message(pid, "echo test\n", [])
 
       Process.sleep(100)
 

--- a/test/hermes/transport/websocket_test.exs
+++ b/test/hermes/transport/websocket_test.exs
@@ -112,7 +112,7 @@ if Code.ensure_loaded?(:gun) do
 
         assert Process.alive?(ws_pid)
 
-        assert :ok = WebSocket.send_message(ws_pid, test_message)
+        assert :ok = WebSocket.send_message(ws_pid, test_message, [])
 
         assert_receive {:message_sent, ^test_message}, 1000
 

--- a/test/support/mock_transport.ex
+++ b/test/support/mock_transport.ex
@@ -6,7 +6,7 @@ defmodule MockTransport do
   def start_link(_opts), do: {:ok, self()}
 
   @impl true
-  def send_message(_, _), do: :ok
+  def send_message(_, _, _), do: :ok
 
   @impl true
   def shutdown(_), do: :ok

--- a/test/support/stub_transport.ex
+++ b/test/support/stub_transport.ex
@@ -80,7 +80,7 @@ defmodule StubTransport do
   end
 
   @impl true
-  def send_message(transport \\ __MODULE__, message) do
+  def send_message(transport \\ __MODULE__, message, _opts \\ []) do
     GenServer.call(transport, {:send_message, message})
   end
 


### PR DESCRIPTION
## Problem

Currently, method `GenServer.call` used on transports have a default timeout of 5s.
Despite allowing to pass http options such as the timeout to be used in the request, the GenServer will throw a timeout after 5s.
## Solution

Use a timeout param on `GenServer.call` from opts

## Rationale

opts will allow us to propagate any other config in the future
