### PR TITLE
fix: don't validate output schema on tool error responses

### DIFF
--- a/lib/hermes/server/handlers/tools.ex
+++ b/lib/hermes/server/handlers/tools.ex
@@ -79,6 +79,10 @@ defmodule Hermes.Server.Handlers.Tools do
     {:reply, Response.to_protocol(resp), frame}
   end
 
+  defp maybe_validate_output_schema(_tool, %Response{isError: true} = resp, frame) do
+    {:reply, Response.to_protocol(resp), frame}
+  end
+
   defp maybe_validate_output_schema(%Tool{} = tool, %Response{structured_content: nil}, frame) do
     metadata = %{tool_name: tool.name}
     {:error, Error.execution(@output_schema_err, metadata), frame}


### PR DESCRIPTION
## Problem

The output schema should only apply to normal responses and not errors.

## Solution

Validation is skipped when the Response struct isError is true.

## Rationale

It's modeled after the existing other case of skipping output schema validation (where there isn't a schema).
