### PR TITLE
fix: remove the default mcp path for streamable http

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 27.3
+erlang 27.3.4
 elixir 1.19.0-rc.0-otp-27

--- a/lib/hermes/transport/streamable_http.ex
+++ b/lib/hermes/transport/streamable_http.ex
@@ -266,10 +266,10 @@ defmodule Hermes.Transport.StreamableHTTP do
       headers: headers
     })
 
-    request = HTTP.build(:post, url, headers, message, options) |> dbg()
+    request = HTTP.build(:post, url, headers, message, options)
 
     request
-    |> HTTP.follow_redirect() |> dbg()
+    |> HTTP.follow_redirect()
     |> case do
       {:ok, %{status: status} = response} when status in 200..299 ->
         {:ok, response}

--- a/lib/hermes/transport/streamable_http.ex
+++ b/lib/hermes/transport/streamable_http.ex
@@ -83,7 +83,7 @@ defmodule Hermes.Transport.StreamableHTTP do
     name: {{:custom, &Hermes.genserver_name/1}, {:default, __MODULE__}},
     client: {:required, Hermes.get_schema(:process_name)},
     base_url: {:required, {:string, {:transform, &URI.new!/1}}},
-    mcp_path: {:string, {:default, "/mcp/"}},
+    mcp_path: {:string, {:default, "/"}},
     headers: {:map, {:default, %{}}},
     transport_opts: {:any, {:default, []}},
     http_options: {:any, {:default, []}},
@@ -266,10 +266,10 @@ defmodule Hermes.Transport.StreamableHTTP do
       headers: headers
     })
 
-    request = HTTP.build(:post, url, headers, message, options)
+    request = HTTP.build(:post, url, headers, message, options) |> dbg()
 
     request
-    |> HTTP.follow_redirect()
+    |> HTTP.follow_redirect() |> dbg()
     |> case do
       {:ok, %{status: status} = response} when status in 200..299 ->
         {:ok, response}

--- a/test/hermes/transport/streamable_http_test.exs
+++ b/test/hermes/transport/streamable_http_test.exs
@@ -53,7 +53,8 @@ defmodule Hermes.Transport.StreamableHTTPTest do
 
       Process.sleep(100)
 
-      _state = :sys.get_state(transport)
+      state = :sys.get_state(transport)
+      assert state.mcp_url.path == "/"
 
       StreamableHTTP.shutdown(transport)
       StubClient.clear_messages()


### PR DESCRIPTION
## Problem

We force to add `/mcp` in all url for streamable http.

## Solution

We remove this implicit rule.

## Rationale

We normally add the whole path with the url when setup the transport.
