### PR TITLE
Adds `resources/templates/list` method for clients

### DIFF
--- a/lib/hermes/client.ex
+++ b/lib/hermes/client.ex
@@ -166,6 +166,18 @@ defmodule Hermes.Client do
       def list_resources(opts \\ []), do: Base.list_resources(__MODULE__, opts)
 
       @doc """
+      Lists all available resource templates from the server.
+
+      ## Options
+        * `:cursor` - Pagination cursor
+        * `:timeout` - Request timeout in milliseconds
+
+      ## Examples
+          {:ok, resources} = MyClient.list_resources_templates()
+      """
+      def list_resource_templates(opts \\ []), do: Base.list_resource_templates(__MODULE__, opts)
+
+      @doc """
       Reads a specific resource by URI.
 
       ## Examples

--- a/lib/hermes/client/base.ex
+++ b/lib/hermes/client/base.ex
@@ -208,6 +208,34 @@ defmodule Hermes.Client.Base do
   end
 
   @doc """
+  Lists available resource templates from the server.
+
+  ## Options
+
+    * `:cursor` - Pagination cursor for continuing a previous request
+    * `:timeout` - Request timeout in milliseconds
+    * `:progress` - Progress tracking options
+      * `:token` - A unique token to track progress (string or integer)
+      * `:callback` - A function to call when progress updates are received
+  """
+  @spec list_resource_templates(t, keyword) :: {:ok, Response.t()} | {:error, Error.t()}
+  def list_resource_templates(client, opts \\ []) do
+    cursor = Keyword.get(opts, :cursor)
+    params = if cursor, do: %{"cursor" => cursor}, else: %{}
+
+    operation =
+      Operation.new(%{
+        method: "resources/templates/list",
+        params: params,
+        progress_opts: Keyword.get(opts, :progress),
+        timeout: Keyword.get(opts, :timeout)
+      })
+
+    buffer_timeout = operation.timeout + to_timeout(second: 1)
+    GenServer.call(client, {:operation, operation}, buffer_timeout)
+  end
+
+  @doc """
   Reads a specific resource from the server.
 
   ## Options

--- a/lib/hermes/mcp/message.ex
+++ b/lib/hermes/mcp/message.ex
@@ -9,7 +9,7 @@ defmodule Hermes.MCP.Message do
 
   # MCP message schemas
 
-  @request_methods ~w(initialize ping resources/list resources/read prompts/get prompts/list tools/call tools/list logging/setLevel completion/complete roots/list sampling/createMessage)
+  @request_methods ~w(initialize ping resources/list resources/templates/list resources/read prompts/get prompts/list tools/call tools/list logging/setLevel completion/complete roots/list sampling/createMessage)
 
   @init_params_schema %{
     "protocolVersion" => {:required, :string},

--- a/test/hermes/client/base_test.exs
+++ b/test/hermes/client/base_test.exs
@@ -98,6 +98,36 @@ defmodule Hermes.Client.BaseTest do
       assert response.is_error == false
     end
 
+    test "list_resource_templates sends correct request", %{client: client} do
+      expect(Hermes.MockTransport, :send_message, fn _, message, _opts ->
+        decoded = JSON.decode!(message)
+        assert decoded["method"] == "resources/templates/list"
+        assert decoded["params"] == %{}
+        :ok
+      end)
+
+      task = Task.async(fn -> Hermes.Client.Base.list_resource_templates(client) end)
+
+      Process.sleep(50)
+
+      request_id = get_request_id(client, "resources/templates/list")
+      assert request_id
+
+      resources = [%{"name" => "test", "uriTemplate" => "test://uri/{some-param}"}]
+      response = resources_templates_list_response(request_id, resources)
+      send_response(client, response)
+
+      expected_result = %{
+        "resourceTemplates" => resources,
+        "nextCursor" => nil
+      }
+
+      assert {:ok, response} = Task.await(task)
+      assert %Response{} = response
+      assert response.result == expected_result
+      assert response.is_error == false
+    end
+
     test "list_resources with cursor", %{client: client} do
       expect(Hermes.MockTransport, :send_message, fn _, message, _opts ->
         decoded = JSON.decode!(message)

--- a/test/support/mcp/builders.ex
+++ b/test/support/mcp/builders.ex
@@ -93,6 +93,10 @@ defmodule Hermes.MCP.Builders do
     build_response(%{"resources" => resources, "nextCursor" => nil}, request_id)
   end
 
+  def resources_templates_list_response(request_id, resources) do
+    build_response(%{"resourceTemplates" => resources, "nextCursor" => nil}, request_id)
+  end
+
   def resources_read_response(request_id, contents) do
     build_response(%{"contents" => contents}, request_id)
   end


### PR DESCRIPTION
## Problem

Current client implementations do not support the `resources/templates/list` method, as described in the MCP spec.
<!-- what problem is the PR is trying to solve? -->

## Solution
This adds a new method to the macro that generate Clients, as well as adding behavior to `HermesMCP.Client.Base`
<!-- how is the PR solving the problem? -->

## Rationale
Clients should be able to use resource templates in the same way that resources are used
<!-- why was it implemented the way it was? -->
