### PR TITLE
Allow any JSON-encodable type for structured response

### DIFF
--- a/lib/hermes/server/response.ex
+++ b/lib/hermes/server/response.ex
@@ -33,7 +33,7 @@ defmodule Hermes.Server.Response do
           total: integer | nil,
           hasMore: boolean,
           isError: boolean,
-          structured_content: map | nil,
+          structured_content: term,
           metadata: map
         }
 
@@ -180,7 +180,7 @@ defmodule Hermes.Server.Response do
         isError: false
       }
   """
-  @spec json(t(), data :: map, annotations) :: t
+  @spec json(t(), data :: term, annotations) :: t
   def json(%{type: type} = r, data, opts \\ []) when type in ~w(tool resource)a do
     text(r, JSON.encode!(data), opts)
   end
@@ -194,7 +194,7 @@ defmodule Hermes.Server.Response do
   ## Parameters
 
     * `response` - A tool response struct
-    * `data` - A map containing the structured data
+    * `data` - Any JSON-encodable data (typically map or list)
 
   ## Examples
 
@@ -205,9 +205,17 @@ defmodule Hermes.Server.Response do
         structured_content: %{temperature: 22.5, conditions: "Partly cloudy"},
         isError: false
       }
+
+      iex> Response.tool() |> Response.structured([1, 2, 3])
+      %Response{
+        type: :tool,
+        content: [%{"type" => "text", "text" => "[1,2,3]"}],
+        structured_content: [1, 2, 3],
+        isError: false
+      }
   """
-  @spec structured(t(), data :: map) :: t
-  def structured(%{type: :tool} = r, data) when is_map(data) do
+  @spec structured(t(), data :: term) :: t
+  def structured(%{type: :tool} = r, data) do
     r
     |> json(data)
     |> Map.put(:structured_content, data)

--- a/test/hermes/server/response_test.exs
+++ b/test/hermes/server/response_test.exs
@@ -159,7 +159,7 @@ defmodule Hermes.Server.ResponseTest do
              }
     end
 
-    test "builds a structured response" do
+    test "builds a structured response with map" do
       result =
         Response.tool()
         |> Response.structured(%{temperature: 22.5, conditions: "Partly cloudy"})
@@ -178,6 +178,27 @@ defmodule Hermes.Server.ResponseTest do
 
       assert {:ok, decoded} = JSON.decode(text)
       assert decoded == %{"temperature" => 22.5, "conditions" => "Partly cloudy"}
+    end
+
+    test "builds a structured response with list" do
+      result =
+        Response.tool()
+        |> Response.structured([1, 2, 3])
+        |> Response.to_protocol()
+
+      assert %{
+               "content" => [
+                 %{
+                   "type" => "text",
+                   "text" => text
+                 }
+               ],
+               "structuredContent" => [1, 2, 3],
+               "isError" => false
+             } = result
+
+      assert {:ok, decoded} = JSON.decode(text)
+      assert decoded == [1, 2, 3]
     end
 
     test "builds content with annotations" do


### PR DESCRIPTION
## Problem

The `structured_content` field in `Hermes.Server.Response` was restricted to only accept maps.

## Solution

Changed the type specification of `structured_content` from `map | nil` to `term`, allowing any JSON-encodable type to be used. Updated the `Response.structured/2` and `Response.json/3` functions to accept `term` instead of just `map`, enabling structured responses to return lists, primitives, or any other JSON-encodable data structure.

## Rationale

The implementation only updates type specs and guards, maintaining backward compatibility while aligning with the MCP protocol's support for various JSON types.
