### PR TITLE
fix(stdio): iterate over decoded messages list

### DIFF
--- a/lib/hermes/server/transport/stdio.ex
+++ b/lib/hermes/server/transport/stdio.ex
@@ -240,7 +240,7 @@ defmodule Hermes.Server.Transport.STDIO do
 
     case Message.decode(data) do
       {:ok, messages} ->
-        process_message(messages, state)
+        Enum.each(messages, &process_message(&1, state))
 
       {:error, reason} ->
         Logging.transport_event("parse_error", %{reason: reason}, level: :error)


### PR DESCRIPTION
## Summary

Fixes #240

`Message.decode/1` returns a list of messages, but `process_message/2` expects a single message (map). This caused a `BadMapError` when processing any incoming stdio message.

## Changes

- Iterate over the decoded messages list using `Enum.each/2` before calling `process_message/2` for each message

## Before (broken)

```elixir
case Message.decode(data) do
  {:ok, messages} ->
    process_message(messages, state)  # messages is a list, crashes
```

## After (fixed)

```elixir
case Message.decode(data) do
  {:ok, messages} ->
    Enum.each(messages, &process_message(&1, state))  # properly handles list
```

## Testing

- All existing tests pass (442 tests, 1 unrelated failure in HTTP transport)
- Manually tested with MCP stdio server - initialize requests now work correctly