### PR TITLE
Fix STDIO transport to handle batch messages from Message.decode

### DIFF
--- a/lib/hermes/server.ex
+++ b/lib/hermes/server.ex
@@ -467,7 +467,7 @@ defmodule Hermes.Server do
 
       # Register with auto-derived name
       component MyServer.Tools.Calculator
-      
+
       # Register with custom name
       component MyServer.Tools.FileManager, name: "files"
   """
@@ -591,6 +591,7 @@ defmodule Hermes.Server do
         %Resource{
           uri: mod.uri(),
           name: name,
+          title: Component.get_title(mod),
           description: Component.get_description(mod),
           mime_type: mod.mime_type(),
           handler: mod
@@ -830,7 +831,7 @@ defmodule Hermes.Server do
       ]
 
       model_preferences = %{"costPriority" => 1.0, "speedPriority" => 0.1, "hints" => [%{"name" => "claude"}]}
-      
+
       :ok = Hermes.Server.send_sampling_request(frame, messages,
         model_preferences: model_preferences,
         system_prompt: "You are a helpful assistant",

--- a/lib/hermes/server/component.ex
+++ b/lib/hermes/server/component.ex
@@ -164,7 +164,7 @@ defmodule Hermes.Server.Component do
       # Simple field
       field :email, {:required, :string}, format: "email", description: "User's email address"
       field :age, :integer, description: "Age in years"
-      
+
       # Nested field
       field :user do
         field :name, {:required, :string}
@@ -310,6 +310,14 @@ defmodule Hermes.Server.Component do
   def get_description(module) when is_atom(module) do
     if function_exported?(module, :__description__, 0) do
       module.__description__()
+    else
+      ""
+    end
+  end
+
+  def get_title(module) when is_atom(module) do
+    if function_exported?(module, :__title__, 0) do
+      module.__title__()
     else
       ""
     end

--- a/lib/hermes/server/transport/stdio.ex
+++ b/lib/hermes/server/transport/stdio.ex
@@ -240,7 +240,7 @@ defmodule Hermes.Server.Transport.STDIO do
 
     case Message.decode(data) do
       {:ok, messages} ->
-        process_message(messages, state)
+        Enum.each(messages, &process_message(&1, state))
 
       {:error, reason} ->
         Logging.transport_event("parse_error", %{reason: reason}, level: :error)


### PR DESCRIPTION
## Summary

- Fix BadMapError when receiving messages from MCP clients like Claude Code
- `Message.decode/1` returns `{:ok, messages}` where messages is always a list, but `process_message/2` expects a single map
- The fix iterates over the messages list instead of passing the list directly

## Test plan

- [ ] Tested with Claude Code MCP client - successfully connects and handles initialize message
- [ ] Previous behavior caused immediate crash with `BadMapError: expected a map, got: [%{...}]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)