### PR TITLE
Fix STDIO transport crashing on incoming messages

### DIFF
--- a/lib/hermes/server/transport/stdio.ex
+++ b/lib/hermes/server/transport/stdio.ex
@@ -240,7 +240,7 @@ defmodule Hermes.Server.Transport.STDIO do
 
     case Message.decode(data) do
       {:ok, messages} ->
-        process_message(messages, state)
+        Enum.each(messages, &process_message(&1, state))
 
       {:error, reason} ->
         Logging.transport_event("parse_error", %{reason: reason}, level: :error)


### PR DESCRIPTION
## Summary

- `Message.decode/1` returns `{:ok, messages}` where `messages` is always a list, but the STDIO transport passed this list directly to `process_message/2` which expects a single map
- This caused a `BadMapError` on every incoming message via the STDIO transport
- The StreamableHTTP transport already handles this correctly by pattern-matching `{:ok, [message]}` in `handle_post/2`
- Fix: iterate over the decoded messages list with `Enum.each/2`

## Test plan

- [x] Verified the fix resolves the `BadMapError` by sending `initialize`, `notifications/initialized`, and `tools/list` messages over stdio
- [x] Confirmed the StreamableHTTP Plug transport already destructures the list correctly (reference implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)