### PR TITLE
fix: prevent GenServer.call timeout crash in StreamableHTTP Plug

### DIFF
--- a/lib/hermes/server/transport/streamable_http.ex
+++ b/lib/hermes/server/transport/streamable_http.ex
@@ -154,10 +154,10 @@ defmodule Hermes.Server.Transport.StreamableHTTP do
 
   Called by the Plug when a message is received via HTTP POST.
   """
-  @spec handle_message(GenServer.server(), String.t(), map() | list(map), map()) ::
+  @spec handle_message(GenServer.server(), String.t(), map() | list(map), map(), timeout()) ::
           {:ok, binary() | nil} | {:error, term()}
-  def handle_message(transport, session_id, message, context) do
-    GenServer.call(transport, {:handle_message, session_id, message, context})
+  def handle_message(transport, session_id, message, context, timeout \\ :infinity) do
+    GenServer.call(transport, {:handle_message, session_id, message, context}, timeout)
   end
 
   @doc """
@@ -165,13 +165,18 @@ defmodule Hermes.Server.Transport.StreamableHTTP do
 
   This allows the Plug to know whether to stream the response via SSE
   or return it as a regular HTTP response.
+
+  The `timeout` parameter controls how long the caller waits for the transport
+  GenServer to reply. Defaults to `:infinity` since the actual request timeout
+  is enforced internally by the transport's `request_timeout` option.
   """
-  @spec handle_message_for_sse(GenServer.server(), String.t(), map(), map()) ::
+  @spec handle_message_for_sse(GenServer.server(), String.t(), map(), map(), timeout()) ::
           {:ok, binary()} | {:sse, binary()} | {:error, term()}
-  def handle_message_for_sse(transport, session_id, message, context) do
+  def handle_message_for_sse(transport, session_id, message, context, timeout \\ :infinity) do
     GenServer.call(
       transport,
-      {:handle_message_for_sse, session_id, message, context}
+      {:handle_message_for_sse, session_id, message, context},
+      timeout
     )
   end
 

--- a/lib/hermes/server/transport/streamable_http/plug.ex
+++ b/lib/hermes/server/transport/streamable_http/plug.ex
@@ -261,6 +261,10 @@ if Code.ensure_loaded?(Plug) do
         {:error, error} ->
           handle_request_error(conn, error, body)
       end
+    catch
+      :exit, reason ->
+        Logging.transport_event("request_exit", %{reason: inspect(reason)}, level: :error)
+        handle_request_error(conn, {:exit, reason}, body)
     end
 
     defp handle_json_request(conn, transport, session_id, body, context, session_header) do
@@ -274,6 +278,10 @@ if Code.ensure_loaded?(Plug) do
         {:error, error} ->
           handle_request_error(conn, error, body)
       end
+    catch
+      :exit, reason ->
+        Logging.transport_event("request_exit", %{reason: inspect(reason)}, level: :error)
+        handle_request_error(conn, {:exit, reason}, body)
     end
 
     defp route_sse_response(conn, transport, session_id, response, body, context, session_header) do


### PR DESCRIPTION
## Problem

`handle_message_for_sse/4` and `handle_message/4` in `StreamableHTTP` use the default 5s `GenServer.call` timeout. When a tool handler takes longer than 5 seconds (common for LLM-backed tools, database queries, or network calls), the `GenServer.call` raises an unhandled `:exit` that crashes the Plug process. The MCP client receives a generic HTTP connection error with no indication of what went wrong.

The transport already has a configurable `request_timeout` (default 30s) that's correctly used for the internal `forward_request_to_server` call — but the outer `GenServer.call` from the public API functions times out first.

## Fix

1. **Default `GenServer.call` timeout to `:infinity`** for `handle_message/5` and `handle_message_for_sse/5`, since the actual timeout is already enforced internally via the transport's `request_timeout` option. A new optional `timeout` parameter is added for callers that want explicit control.

2. **Catch `:exit` in the Plug** for both `handle_sse_request` and `handle_json_request`, returning a proper JSON-RPC internal error response instead of silently crashing the connection.

## Test plan

- [x] Existing `streamable_http_test.exs` tests pass (9 tests)
- [x] Existing `streamable_http/plug` tests pass (15 tests)
- [ ] Manual verification: tool calls taking >5s return proper JSON-RPC error responses instead of connection drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)