### PR TITLE
fix(stdio): iterate decoded message list in process_message dispatch

### DIFF
--- a/lib/hermes/server/transport/stdio.ex
+++ b/lib/hermes/server/transport/stdio.ex
@@ -240,7 +240,7 @@ defmodule Hermes.Server.Transport.STDIO do
 
     case Message.decode(data) do
       {:ok, messages} ->
-        process_message(messages, state)
+        Enum.each(messages, &process_message(&1, state))
 
       {:error, reason} ->
         Logging.transport_event("parse_error", %{reason: reason}, level: :error)


### PR DESCRIPTION
## Summary

- `Message.decode/1` returns `{:ok, messages}` where `messages` is always a **list** (see `message.ex:376`)
- The STDIO transport at `stdio.ex:243` passed this list directly to `process_message/2`, which expects a single **map**
- This caused a `BadMapError` on every incoming JSON-RPC message, making the STDIO server transport completely non-functional

## Fix

Iterate the decoded list with `Enum.each/2` before dispatching each message individually — matching how the client-side code (`client/base.ex:971`) and other transports (SSE via pattern match `{:ok, [message]}`) already handle the list return.

## Before (broken)

```elixir
case Message.decode(data) do
  {:ok, messages} ->
    process_message(messages, state)  # messages is a list, process_message expects a map
```

## After (fixed)

```elixir
case Message.decode(data) do
  {:ok, messages} ->
    Enum.each(messages, &process_message(&1, state))
```

## Verification

Tested against a real MCP client (roundtable) — the STDIO transport now correctly handles `initialize`, `tools/call`, and other JSON-RPC messages. All existing tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)