### PR TITLE
fix: recover STDIO transport from crashed reading tasks

### DIFF
--- a/lib/hermes/server/transport/stdio.ex
+++ b/lib/hermes/server/transport/stdio.ex
@@ -144,6 +144,23 @@ defmodule Hermes.Server.Transport.STDIO do
     end
   end
 
+  def handle_info({:DOWN, _ref, :process, pid, reason}, %{reading_task: %Task{pid: pid}} = state) do
+    # Reading task crashed without delivering a result.
+    # Without this clause the catch-all swallows the signal
+    # and no new reading task is ever started — the transport
+    # stays alive but deaf to stdin.
+    Logging.transport_event("reading_task_crashed", %{reason: reason}, level: :error)
+    task = Task.async(fn -> read_from_stdin() end)
+    {:noreply, %{state | reading_task: task}}
+  end
+
+  def handle_info({:EXIT, pid, reason}, %{reading_task: %Task{pid: pid}} = state)
+      when reason != :normal do
+    Logging.transport_event("reading_task_exit", %{reason: reason}, level: :error)
+    task = Task.async(fn -> read_from_stdin() end)
+    {:noreply, %{state | reading_task: task}}
+  end
+
   def handle_info(_msg, state) do
     {:noreply, state}
   end
@@ -240,7 +257,7 @@ defmodule Hermes.Server.Transport.STDIO do
 
     case Message.decode(data) do
       {:ok, messages} ->
-        process_message(messages, state)
+        Enum.each(messages, &process_message(&1, state))
 
       {:error, reason} ->
         Logging.transport_event("parse_error", %{reason: reason}, level: :error)


### PR DESCRIPTION
## Summary

- **Task crash recovery**: If the `Task.async` reading task crashes instead of returning `{:error, :eof}`, the transport's catch-all `handle_info(_msg, state)` silently drops the EXIT/DOWN signals. No new reading task is started — the transport stays alive but deaf to stdin. This adds explicit `handle_info` clauses for `{:DOWN, ...}` and `{:EXIT, ...}` from the reading task that log the error and start a new reading task.
- **Multi-message dispatch fix**: `handle_incoming_data` passed the full message list to `process_message/2` instead of iterating with `Enum.each/2`, causing a `FunctionClauseError` when a single `IO.read` returned multiple newline-delimited JSON-RPC messages.

## Reproduction

1. Start an MCP server with STDIO transport handling long-running tool calls (500+ seconds)
2. After a few successful calls, the transport enters a state where it appears "Connected" but all tool calls hang indefinitely
3. No error output, no timeout — the BEAM process stays alive with a healthy-looking stdio pipe
4. Only fix is to kill the BEAM process manually

## Test plan

- [ ] Existing STDIO transport tests pass
- [ ] Manual test: kill the reading task from `iex` — transport should recover and continue reading
- [ ] Verify EXIT with `:normal` reason is still handled by the catch-all (no false recovery)