### PR TITLE
feat: add deferred tool-call reply support

### DIFF
--- a/lib/hermes/server.ex
+++ b/lib/hermes/server.ex
@@ -134,11 +134,24 @@ defmodule Hermes.Server do
   This callback handles both module-based components (registered with `component`) and
   runtime components (registered with `Frame.register_tool/3`). For module-based tools,
   the framework automatically generates pattern-matched clauses during compilation.
+
+  ## Deferred replies
+
+  Returning `{:defer, ref, opts, frame}` suspends the transport caller until
+  `Hermes.Server.deferred_reply/3` or `Hermes.Server.cancel_deferred/2` is called
+  with the same `ref`.
+
+  The `opts` map accepts:
+
+    * `:cancel_notify` (`t:pid/0 | nil`) — if set, this pid receives
+      `{:deferred_cancelled, ref}` whenever the deferred reply is cancelled,
+      either explicitly via `cancel_deferred/2`, via a `notifications/cancelled`
+      message from the client, or because the original caller process died.
   """
   @callback handle_tool_call(name :: String.t(), arguments :: map(), Frame.t()) ::
               {:reply, result :: term(), Frame.t()}
               | {:error, mcp_error(), Frame.t()}
-              | {:defer, ref :: reference(), opts :: map(), Frame.t()}
+              | {:defer, ref :: reference(), opts :: %{optional(:cancel_notify) => pid() | nil}, Frame.t()}
 
   @doc """
   Handles a resource read request.

--- a/lib/hermes/server.ex
+++ b/lib/hermes/server.ex
@@ -138,6 +138,7 @@ defmodule Hermes.Server do
   @callback handle_tool_call(name :: String.t(), arguments :: map(), Frame.t()) ::
               {:reply, result :: term(), Frame.t()}
               | {:error, mcp_error(), Frame.t()}
+              | {:defer, ref :: reference(), opts :: map(), Frame.t()}
 
   @doc """
   Handles a resource read request.
@@ -880,5 +881,49 @@ defmodule Hermes.Server do
     pid = registry.whereis_server(server)
     send(pid, {:send_roots_request, timeout})
     :ok
+  end
+
+  # Deferred Reply API
+
+  @doc """
+  Resolves a previously deferred tool call reply.
+
+  When a `handle_tool_call/3` callback returns `{:defer, ref, opts, frame}`, the
+  transport caller blocks naturally (via GenServer call semantics) until this function
+  is called with the same `ref`.
+
+  The `response` map should contain either a `"result"` key (for success) or an
+  `"error"` key (for errors). If a plain map is provided, it is wrapped as
+  `%{"result" => response}`.
+
+  Calling this function with a `ref` that has already been resolved or cancelled
+  is a no-op (one-shot idempotent).
+
+  ## Examples
+
+      # From within a process that received the ref
+      Hermes.Server.deferred_reply(server, ref, %{"result" => %{"content" => [...]}})
+
+      # Or resolve with an error
+      Hermes.Server.deferred_reply(server, ref, %{"error" => %{"code" => -1, "message" => "failed"}})
+  """
+  @spec deferred_reply(GenServer.server(), reference(), map()) :: :ok
+  def deferred_reply(server, ref, response) when is_reference(ref) and is_map(response) do
+    GenServer.cast(server, {:deferred_reply, ref, response})
+  end
+
+  @doc """
+  Cancels a previously deferred tool call reply.
+
+  The transport caller receives `{:error, :cancelled}` and the session request
+  is completed. If a `cancel_notify` pid was specified in the defer opts, it
+  receives a `{:deferred_cancelled, ref}` message.
+
+  Calling this function with a `ref` that has already been resolved or cancelled
+  is a no-op (one-shot idempotent).
+  """
+  @spec cancel_deferred(GenServer.server(), reference()) :: :ok
+  def cancel_deferred(server, ref) when is_reference(ref) do
+    GenServer.cast(server, {:cancel_deferred, ref})
   end
 end

--- a/lib/hermes/server/base.ex
+++ b/lib/hermes/server/base.ex
@@ -39,6 +39,15 @@ defmodule Hermes.Server.Base do
               metadata: map(),
               timer_ref: reference()
             }
+          },
+          deferred_replies: %{
+            required(reference()) => %{
+              from: GenServer.from(),
+              session: GenServer.name(),
+              request_id: String.t(),
+              cancel_notify: pid() | nil,
+              monitor_ref: reference()
+            }
           }
         }
 
@@ -90,7 +99,8 @@ defmodule Hermes.Server.Base do
       session_idle_timeout: opts.session_idle_timeout,
       expiry_timers: %{},
       frame: Frame.new(),
-      server_requests: %{}
+      server_requests: %{},
+      deferred_replies: %{}
     }
 
     Logging.server_event("starting", %{
@@ -109,7 +119,7 @@ defmodule Hermes.Server.Base do
   end
 
   @impl GenServer
-  def handle_call({:request, decoded, session_id, context}, _from, state) when is_map(decoded) do
+  def handle_call({:request, decoded, session_id, context}, from, state) when is_map(decoded) do
     with {:ok, {%Session{} = session, state}} <-
            maybe_attach_session(session_id, context, state) do
       case handle_single_request(decoded, session, state) do
@@ -129,6 +139,30 @@ defmodule Hermes.Server.Base do
           request_id = decoded["id"]
           if request_id, do: Session.complete_request(session.name, request_id)
           {:reply, {:error, error}, new_state}
+
+        {:defer, ref, opts, frame} ->
+          request_id = decoded["id"]
+          {caller_pid, _} = from
+          monitor_ref = Process.monitor(caller_pid)
+
+          entry = %{
+            from: from,
+            session: session.name,
+            request_id: request_id,
+            cancel_notify: opts[:cancel_notify],
+            monitor_ref: monitor_ref
+          }
+
+          new_state = %{state | frame: frame}
+          new_state = put_in(new_state.deferred_replies[ref], entry)
+
+          Logging.server_event("deferred_reply_registered", %{
+            ref: inspect(ref),
+            request_id: request_id,
+            session_id: session_id
+          })
+
+          {:noreply, new_state}
       end
     end
   end
@@ -192,6 +226,49 @@ defmodule Hermes.Server.Base do
     end
   end
 
+  def handle_cast({:deferred_reply, ref, response}, state) do
+    case Map.pop(state.deferred_replies, ref) do
+      {nil, _} ->
+        Logging.server_event("deferred_reply_already_resolved", %{ref: inspect(ref)})
+        {:noreply, state}
+
+      {entry, remaining} ->
+        Process.demonitor(entry.monitor_ref, [:flush])
+
+        encoded = encode_deferred_response(response, entry.request_id)
+        GenServer.reply(entry.from, encoded)
+        Session.complete_request(entry.session, entry.request_id)
+
+        Logging.server_event("deferred_reply_resolved", %{
+          ref: inspect(ref),
+          request_id: entry.request_id
+        })
+
+        {:noreply, %{state | deferred_replies: remaining}}
+    end
+  end
+
+  def handle_cast({:cancel_deferred, ref}, state) do
+    case Map.pop(state.deferred_replies, ref) do
+      {nil, _} ->
+        Logging.server_event("deferred_cancel_already_resolved", %{ref: inspect(ref)})
+        {:noreply, state}
+
+      {entry, remaining} ->
+        Process.demonitor(entry.monitor_ref, [:flush])
+        GenServer.reply(entry.from, {:error, :cancelled})
+        Session.complete_request(entry.session, entry.request_id)
+        notify_cancel(entry.cancel_notify, ref)
+
+        Logging.server_event("deferred_reply_cancelled", %{
+          ref: inspect(ref),
+          request_id: entry.request_id
+        })
+
+        {:noreply, %{state | deferred_replies: remaining}}
+    end
+  end
+
   def handle_cast(request, %{module: module} = state) do
     case module.handle_cast(request, state.frame) do
       {:noreply, frame} -> {:noreply, %{state | frame: frame}}
@@ -201,7 +278,7 @@ defmodule Hermes.Server.Base do
   end
 
   @impl GenServer
-  def handle_info({:DOWN, ref, :process, _pid, reason}, state) do
+  def handle_info({:DOWN, ref, :process, pid, reason}, state) do
     session_entry =
       Enum.find(state.sessions, fn
         {_id, {_name, ^ref}} -> true
@@ -217,6 +294,7 @@ defmodule Hermes.Server.Base do
 
         sessions = Map.delete(state.sessions, session_id)
         state = cancel_session_expiry(session_id, state)
+        state = sweep_deferred_for_session(session_id, state)
         frame = state.frame
 
         frame =
@@ -227,7 +305,31 @@ defmodule Hermes.Server.Base do
         {:noreply, %{state | sessions: sessions, frame: frame}}
 
       nil ->
-        {:noreply, state}
+        # Check if this is a deferred reply caller that died
+        deferred_entry =
+          Enum.find(state.deferred_replies, fn
+            {_ref, %{monitor_ref: ^ref}} -> true
+            _ -> false
+          end)
+
+        case deferred_entry do
+          {deferred_ref, entry} ->
+            Logging.server_event("deferred_caller_down", %{
+              ref: inspect(deferred_ref),
+              request_id: entry.request_id,
+              pid: inspect(pid),
+              reason: inspect(reason)
+            })
+
+            remaining = Map.delete(state.deferred_replies, deferred_ref)
+            Session.complete_request(entry.session, entry.request_id)
+            notify_cancel(entry.cancel_notify, deferred_ref)
+
+            {:noreply, %{state | deferred_replies: remaining}}
+
+          nil ->
+            {:noreply, state}
+        end
     end
   end
 
@@ -246,6 +348,7 @@ defmodule Hermes.Server.Base do
   def handle_info({:session_expired, session_id}, state) do
     if Map.get(state.sessions, session_id) do
       Logging.server_event("session_expired", %{session_id: session_id})
+      state = sweep_deferred_for_session(session_id, state)
       SessionSupervisor.close_session(state.registry, state.module, session_id)
       {:noreply, %{state | sessions: Map.delete(state.sessions, session_id)}}
     else
@@ -320,7 +423,7 @@ defmodule Hermes.Server.Base do
     end)
   end
 
-  @non_printable_keys ~w(transport sessions expiry_timers server_requests)a
+  @non_printable_keys ~w(transport sessions expiry_timers server_requests deferred_replies)a
 
   defp format_state(state) do
     pending_requests = format_pending_requests(state.server_requests)
@@ -331,7 +434,8 @@ defmodule Hermes.Server.Base do
     |> Map.merge(%{
       transport: state.transport[:layer],
       pending_requests: pending_requests,
-      active_sessions: sessions
+      active_sessions: sessions,
+      deferred_replies: map_size(state.deferred_replies)
     })
   end
 
@@ -577,6 +681,16 @@ defmodule Hermes.Server.Base do
         frame = Frame.clear_request(frame)
 
         {:reply, {:ok, Error.build_json_rpc(error, request_id)}, %{state | frame: frame}}
+
+      {:defer, ref, opts, %Frame{} = frame} ->
+        Telemetry.execute(
+          Telemetry.event_server_response(),
+          %{system_time: System.system_time()},
+          %{id: request_id, method: method, status: :deferred}
+        )
+
+        frame = Frame.clear_request(frame)
+        {:defer, ref, opts, frame}
     end
   end
 
@@ -656,7 +770,8 @@ defmodule Hermes.Server.Base do
       client_capabilities: session.client_capabilities,
       protocol_version: session.protocol_version,
       server_registry: state.registry,
-      server_module: state.module
+      server_module: state.module,
+      server_pid: self()
     })
   end
 
@@ -909,6 +1024,58 @@ defmodule Hermes.Server.Base do
 
       {:stop, reason, new_frame} ->
         {:stop, reason, %{state | frame: new_frame}}
+    end
+  end
+
+  # Deferred reply helpers
+
+  defp notify_cancel(nil, _ref), do: :ok
+
+  defp notify_cancel(pid, ref) when is_pid(pid) do
+    if Process.alive?(pid), do: send(pid, {:deferred_cancelled, ref})
+    :ok
+  end
+
+  defp encode_deferred_response(%{"result" => _} = response, request_id) do
+    Message.encode_response(response, request_id)
+  end
+
+  defp encode_deferred_response(%{"error" => _} = response, request_id) do
+    Message.encode_error(response, request_id)
+  end
+
+  defp encode_deferred_response(result, request_id) when is_map(result) do
+    Message.encode_response(%{"result" => result}, request_id)
+  end
+
+  defp sweep_deferred_for_session(session_id, state) do
+    session_name =
+      case Map.get(state.sessions, session_id) do
+        {name, _ref} -> name
+        nil -> nil
+      end
+
+    if session_name do
+      {to_cancel, to_keep} =
+        Map.split_with(state.deferred_replies, fn {_ref, entry} ->
+          entry.session == session_name
+        end)
+
+      Enum.each(to_cancel, fn {ref, entry} ->
+        Process.demonitor(entry.monitor_ref, [:flush])
+        GenServer.reply(entry.from, {:error, :cancelled})
+        notify_cancel(entry.cancel_notify, ref)
+
+        Logging.server_event("deferred_reply_swept", %{
+          ref: inspect(ref),
+          request_id: entry.request_id,
+          session_id: session_id
+        })
+      end)
+
+      %{state | deferred_replies: Map.new(to_keep)}
+    else
+      state
     end
   end
 end

--- a/lib/hermes/server/base.ex
+++ b/lib/hermes/server/base.ex
@@ -597,33 +597,61 @@ defmodule Hermes.Server.Base do
     request_id = params["requestId"]
     reason = Map.get(params, "reason", "cancelled")
 
-    if Session.has_pending_request?(session.name, request_id) do
-      request_info = Session.complete_request(session.name, request_id)
+    state =
+      if Session.has_pending_request?(session.name, request_id) do
+        request_info = Session.complete_request(session.name, request_id)
 
-      Logging.server_event("request_cancelled", %{
-        session_id: session.id,
-        request_id: request_id,
-        reason: reason,
-        method: request_info[:method],
-        duration_ms: System.system_time(:millisecond) - request_info[:started_at]
-      })
+        Logging.server_event("request_cancelled", %{
+          session_id: session.id,
+          request_id: request_id,
+          reason: reason,
+          method: request_info[:method],
+          duration_ms: System.system_time(:millisecond) - request_info[:started_at]
+        })
 
-      Telemetry.execute(
-        Telemetry.event_server_notification(),
-        %{system_time: System.system_time()},
-        %{method: "cancelled", session_id: session.id, request_id: request_id}
-      )
+        Telemetry.execute(
+          Telemetry.event_server_notification(),
+          %{system_time: System.system_time()},
+          %{method: "cancelled", session_id: session.id, request_id: request_id}
+        )
 
-      {:noreply, state}
-    else
-      Logging.server_event("cancellation_for_unknown_request", %{
-        session_id: session.id,
-        request_id: request_id,
-        reason: reason
-      })
+        state
+      else
+        Logging.server_event("cancellation_for_unknown_request", %{
+          session_id: session.id,
+          request_id: request_id,
+          reason: reason
+        })
 
-      {:noreply, state}
-    end
+        state
+      end
+
+    # Also cancel any deferred entry blocked on this request_id
+    deferred_entry =
+      Enum.find(state.deferred_replies, fn {_ref, entry} ->
+        entry.request_id == request_id
+      end)
+
+    state =
+      case deferred_entry do
+        {deferred_ref, entry} ->
+          Process.demonitor(entry.monitor_ref, [:flush])
+          GenServer.reply(entry.from, {:error, :cancelled})
+          notify_cancel(entry.cancel_notify, deferred_ref)
+
+          Logging.server_event("deferred_reply_cancelled_by_notification", %{
+            ref: inspect(deferred_ref),
+            request_id: request_id,
+            session_id: session.id
+          })
+
+          %{state | deferred_replies: Map.delete(state.deferred_replies, deferred_ref)}
+
+        nil ->
+          state
+      end
+
+    {:noreply, state}
   end
 
   defp handle_notification(notification, _session, state) do
@@ -1064,6 +1092,13 @@ defmodule Hermes.Server.Base do
       Enum.each(to_cancel, fn {ref, entry} ->
         Process.demonitor(entry.monitor_ref, [:flush])
         GenServer.reply(entry.from, {:error, :cancelled})
+
+        try do
+          Session.complete_request(entry.session, entry.request_id)
+        catch
+          :exit, _ -> :ok
+        end
+
         notify_cancel(entry.cancel_notify, ref)
 
         Logging.server_event("deferred_reply_swept", %{

--- a/lib/hermes/server/handlers.ex
+++ b/lib/hermes/server/handlers.ex
@@ -13,6 +13,7 @@ defmodule Hermes.Server.Handlers do
           {:reply, response :: Response.t(), new_state :: Frame.t()}
           | {:noreply, new_state :: Frame.t()}
           | {:error, error :: Error.t(), new_state :: Frame.t()}
+          | {:defer, ref :: reference(), opts :: map(), new_state :: Frame.t()}
   def handle(%{"method" => "tools/" <> action} = request, module, frame) do
     case action do
       "list" -> Tools.handle_list(request, frame, module)

--- a/lib/hermes/server/handlers/tools.ex
+++ b/lib/hermes/server/handlers/tools.ex
@@ -79,6 +79,10 @@ defmodule Hermes.Server.Handlers.Tools do
     {:reply, Response.to_protocol(resp), frame}
   end
 
+  defp maybe_validate_output_schema(_tool, %Response{isError: true} = resp, frame) do
+    {:reply, Response.to_protocol(resp), frame}
+  end
+
   defp maybe_validate_output_schema(%Tool{} = tool, %Response{structured_content: nil}, frame) do
     metadata = %{tool_name: tool.name}
     {:error, Error.execution(@output_schema_err, metadata), frame}

--- a/lib/hermes/server/handlers/tools.ex
+++ b/lib/hermes/server/handlers/tools.ex
@@ -57,6 +57,9 @@ defmodule Hermes.Server.Handlers.Tools do
 
       {:error, %Error{} = error, frame} ->
         {:error, error, frame}
+
+      {:defer, ref, opts, frame} ->
+        {:defer, ref, opts, frame}
     end
   end
 
@@ -70,6 +73,9 @@ defmodule Hermes.Server.Handlers.Tools do
 
       {:error, %Error{} = error, frame} ->
         {:error, error, frame}
+
+      {:defer, ref, opts, frame} ->
+        {:defer, ref, opts, frame}
     end
   end
 

--- a/lib/hermes/server/transport/stdio.ex
+++ b/lib/hermes/server/transport/stdio.ex
@@ -36,7 +36,8 @@ defmodule Hermes.Server.Transport.STDIO do
     {:server, {:required, {:oneof, [{:custom, &Hermes.genserver_name/1}, :pid, {:tuple, [:atom, :any]}]}}},
     {:name, {:custom, &Hermes.genserver_name/1}},
     {:registry, {:atom, {:default, Hermes.Server.Registry}}},
-    {:request_timeout, {:integer, {:default, to_timeout(second: 30)}}}
+    {:request_timeout, {:integer, {:default, to_timeout(second: 30)}}},
+    {:task_supervisor, {:required, {:custom, &Hermes.genserver_name/1}}}
   ])
 
   @doc """
@@ -106,7 +107,9 @@ defmodule Hermes.Server.Transport.STDIO do
       server: opts.server,
       reading_task: nil,
       registry: opts.registry,
-      request_timeout: opts.request_timeout
+      request_timeout: opts.request_timeout,
+      task_supervisor: opts.task_supervisor,
+      active_tasks: %{}
     }
 
     Logger.metadata(mcp_transport: :stdio, mcp_server: state.server)
@@ -133,7 +136,7 @@ defmodule Hermes.Server.Transport.STDIO do
 
     case result do
       {:ok, data} ->
-        handle_incoming_data(data, state)
+        state = handle_incoming_data(data, state)
 
         task = Task.async(fn -> read_from_stdin() end)
         {:noreply, %{state | reading_task: task}}
@@ -142,6 +145,37 @@ defmodule Hermes.Server.Transport.STDIO do
         Logging.transport_event("read_error", %{reason: reason}, level: :error)
         {:stop, {:error, reason}, state}
     end
+  end
+
+  # Handle successful request task completion
+  def handle_info({ref, result}, %{active_tasks: active_tasks} = state)
+      when is_reference(ref) and is_map_key(active_tasks, ref) do
+    {_task_info, active_tasks} = Map.pop(active_tasks, ref)
+    Process.demonitor(ref, [:flush])
+
+    case result do
+      {:ok, response} when is_binary(response) ->
+        send_message(self(), response, [])
+
+      {:error, reason} ->
+        Logging.transport_event("server_error", %{reason: reason}, level: :error)
+    end
+
+    {:noreply, %{state | active_tasks: active_tasks}}
+  end
+
+  # Handle request task crash
+  def handle_info({:DOWN, ref, :process, _pid, reason}, %{active_tasks: active_tasks} = state)
+      when is_map_key(active_tasks, ref) do
+    {_task_info, active_tasks} = Map.pop(active_tasks, ref)
+
+    Logging.transport_event(
+      "task_crashed",
+      %{reason: inspect(reason, pretty: true)},
+      level: :error
+    )
+
+    {:noreply, %{state | active_tasks: active_tasks}}
   end
 
   def handle_info(_msg, state) do
@@ -167,8 +201,12 @@ defmodule Hermes.Server.Transport.STDIO do
   end
 
   @impl GenServer
-  def handle_cast(:shutdown, %{reading_task: task} = state) do
+  def handle_cast(:shutdown, %{reading_task: task, active_tasks: active_tasks} = state) do
     if task, do: Task.shutdown(task, :brutal_kill)
+
+    for {_ref, %{pid: pid}} <- active_tasks do
+      Task.Supervisor.terminate_child(state.task_supervisor, pid)
+    end
 
     Logging.transport_event("shutdown", "Transport shutting down", level: :info)
 
@@ -240,16 +278,16 @@ defmodule Hermes.Server.Transport.STDIO do
 
     case Message.decode(data) do
       {:ok, messages} ->
-        Enum.each(messages, &process_message(&1, state))
+        Enum.reduce(messages, state, &process_message/2)
 
       {:error, reason} ->
         Logging.transport_event("parse_error", %{reason: reason}, level: :error)
+        state
     end
   end
 
   defp process_message(message, %{server: server_name, registry: registry} = state) do
     server = registry.whereis_server(server_name)
-    timeout = state.request_timeout
 
     context = %{
       type: :stdio,
@@ -259,17 +297,25 @@ defmodule Hermes.Server.Transport.STDIO do
 
     if Message.is_notification(message) do
       GenServer.cast(server, {:notification, message, "stdio", context})
+      state
     else
-      case GenServer.call(server, {:request, message, "stdio", context}, timeout) do
-        {:ok, response} when is_binary(response) ->
-          send_message(self(), response, [])
+      task =
+        Task.Supervisor.async(state.task_supervisor, fn ->
+          forward_request_to_server(server, message, context)
+        end)
 
-        {:error, reason} ->
-          Logging.transport_event("server_error", %{reason: reason}, level: :error)
-      end
+      put_in(state.active_tasks[task.ref], %{type: :request, pid: task.pid})
     end
+  end
+
+  defp forward_request_to_server(server, message, context) do
+    # Use :infinity — the server manages request lifecycle via deferred reply
+    # resolution, cancellation, caller DOWN monitoring, and session sweep.
+    # A finite timeout here silently drops deferred replies for long-running work.
+    GenServer.call(server, {:request, message, "stdio", context}, :infinity)
   catch
     :exit, reason ->
       Logging.transport_event("server_call_failed", %{reason: reason}, level: :error)
+      {:error, :server_unavailable}
   end
 end

--- a/lib/hermes/server/transport/stdio.ex
+++ b/lib/hermes/server/transport/stdio.ex
@@ -240,7 +240,7 @@ defmodule Hermes.Server.Transport.STDIO do
 
     case Message.decode(data) do
       {:ok, messages} ->
-        process_message(messages, state)
+        Enum.each(messages, &process_message(&1, state))
 
       {:error, reason} ->
         Logging.transport_event("parse_error", %{reason: reason}, level: :error)

--- a/lib/hermes/server/transport/streamable_http.ex
+++ b/lib/hermes/server/transport/streamable_http.ex
@@ -341,10 +341,13 @@ defmodule Hermes.Server.Transport.StreamableHTTP do
     {:reply, :ok, state}
   end
 
-  defp forward_request_to_server(server, message, session_id, context, timeout, has_sse_handler \\ false) do
+  defp forward_request_to_server(server, message, session_id, context, _timeout, has_sse_handler \\ false) do
     msg = {:request, message, session_id, context}
 
-    case GenServer.call(server, msg, timeout) do
+    # Use :infinity — the server manages request lifecycle via deferred reply
+    # resolution, cancellation, caller DOWN monitoring, and session sweep.
+    # A finite timeout here silently drops deferred replies for long-running work.
+    case GenServer.call(server, msg, :infinity) do
       {:ok, response} when has_sse_handler ->
         {:sse, response}
 

--- a/test/hermes/server/deferred_reply_test.exs
+++ b/test/hermes/server/deferred_reply_test.exs
@@ -303,9 +303,7 @@ defmodule Hermes.Server.DeferredReplyTest do
 
     start_supervised!(Hermes.Server.Registry)
 
-    start_supervised!(
-      {Session.Supervisor, server: DeferredStubServer, registry: Hermes.Server.Registry}
-    )
+    start_supervised!({Session.Supervisor, server: DeferredStubServer, registry: Hermes.Server.Registry})
 
     transport = start_supervised!(StubTransport)
 

--- a/test/hermes/server/deferred_reply_test.exs
+++ b/test/hermes/server/deferred_reply_test.exs
@@ -185,6 +185,91 @@ defmodule Hermes.Server.DeferredReplyTest do
       refute Map.has_key?(state.deferred_replies, ref)
     end
 
+    test "session crash triggers sweep, cleans up deferred entry, and notifies cancel_notify", %{
+      server: server,
+      session_id: session_id
+    } do
+      _task =
+        spawn(fn ->
+          request =
+            build_request("tools/call", %{
+              "name" => "deferred_tool_with_cancel",
+              "arguments" => %{}
+            })
+
+          GenServer.call(server, {:request, request, session_id, %{}})
+        end)
+
+      # Wait for the deferred reply to be registered
+      assert_receive {:deferred_registered, ref}, 1000
+
+      # Verify it's tracked
+      state = :sys.get_state(server)
+      assert Map.has_key?(state.deferred_replies, ref)
+
+      # Kill the session process directly to simulate a crash
+      session_pid = Hermes.Server.Registry.whereis_server_session(DeferredStubServer, session_id)
+      assert is_pid(session_pid)
+      Process.exit(session_pid, :kill)
+
+      # Wait for the DOWN to be processed by the Base GenServer
+      Process.sleep(100)
+
+      # cancel_notify should receive notification
+      assert_receive {:deferred_cancelled, ^ref}, 1000
+
+      # Deferred entry should be cleaned up
+      state = :sys.get_state(server)
+      refute Map.has_key?(state.deferred_replies, ref)
+
+      # Server should still be alive
+      assert Process.alive?(server)
+    end
+
+    test "notifications/cancelled for deferred request unblocks caller and notifies cancel_notify",
+         %{server: server, session_id: session_id} do
+      # Build the request ahead of time so we know the request_id
+      request =
+        build_request("tools/call", %{
+          "name" => "deferred_tool_with_cancel",
+          "arguments" => %{}
+        })
+
+      request_id = request["id"]
+
+      task =
+        Task.async(fn ->
+          GenServer.call(server, {:request, request, session_id, %{}})
+        end)
+
+      # Wait for the deferred reply to be registered
+      assert_receive {:deferred_registered, _ref}, 1000
+
+      # Verify the deferred entry is present
+      state = :sys.get_state(server)
+      assert Enum.any?(state.deferred_replies, fn {_ref, entry} -> entry.request_id == request_id end)
+
+      # Send a notifications/cancelled for the same request_id
+      notification =
+        build_notification("notifications/cancelled", %{
+          "requestId" => request_id,
+          "reason" => "user cancelled"
+        })
+
+      GenServer.cast(server, {:notification, notification, session_id, %{}})
+
+      # The blocked caller should get an error
+      response = Task.await(task, 2000)
+      assert {:error, :cancelled} = response
+
+      # cancel_notify pid should receive notification
+      assert_receive {:deferred_cancelled, _ref}, 1000
+
+      # Deferred entry should be cleaned up
+      state = :sys.get_state(server)
+      refute Enum.any?(state.deferred_replies, fn {_ref, entry} -> entry.request_id == request_id end)
+    end
+
     test "server_pid is available in frame private", %{
       server: server,
       session_id: session_id

--- a/test/hermes/server/deferred_reply_test.exs
+++ b/test/hermes/server/deferred_reply_test.exs
@@ -1,0 +1,253 @@
+defmodule Hermes.Server.DeferredReplyTest do
+  use Hermes.MCP.Case, async: false
+
+  alias Hermes.MCP.Message
+  alias Hermes.Server.Base
+  alias Hermes.Server.Session
+
+  require Message
+
+  @moduletag capture_log: true
+
+  describe "deferred reply" do
+    setup :deferred_server
+
+    test "resolves successfully", %{server: server, session_id: session_id} do
+      task =
+        Task.async(fn ->
+          request = build_request("tools/call", %{"name" => "deferred_tool", "arguments" => %{}})
+          GenServer.call(server, {:request, request, session_id, %{}})
+        end)
+
+      # Wait for the deferred reply to be registered
+      assert_receive {:deferred_registered, ref}, 1000
+
+      # Verify the deferred reply is tracked in state
+      state = :sys.get_state(server)
+      assert Map.has_key?(state.deferred_replies, ref)
+
+      # Resolve the deferred reply
+      result = %{"content" => [%{"type" => "text", "text" => "done"}], "isError" => false}
+      Hermes.Server.deferred_reply(server, ref, %{"result" => result})
+
+      # The blocked caller should now get the response
+      response = Task.await(task, 2000)
+      assert {:ok, encoded} = response
+      assert {:ok, [decoded]} = Message.decode(encoded)
+      assert decoded["result"] == result
+
+      # Deferred entry should be cleaned up
+      state = :sys.get_state(server)
+      refute Map.has_key?(state.deferred_replies, ref)
+    end
+
+    test "resolves with error response", %{server: server, session_id: session_id} do
+      task =
+        Task.async(fn ->
+          request = build_request("tools/call", %{"name" => "deferred_tool", "arguments" => %{}})
+          GenServer.call(server, {:request, request, session_id, %{}})
+        end)
+
+      assert_receive {:deferred_registered, ref}, 1000
+
+      # Resolve with an error
+      error = %{"code" => -32_000, "message" => "Something went wrong"}
+      Hermes.Server.deferred_reply(server, ref, %{"error" => error})
+
+      response = Task.await(task, 2000)
+      assert {:ok, encoded} = response
+      assert {:ok, [decoded]} = Message.decode(encoded)
+      assert decoded["error"]["code"] == -32_000
+      assert decoded["error"]["message"] == "Something went wrong"
+    end
+
+    test "cancel sends error and notifies cancel_notify pid", %{
+      server: server,
+      session_id: session_id
+    } do
+      task =
+        Task.async(fn ->
+          request =
+            build_request("tools/call", %{
+              "name" => "deferred_tool_with_cancel",
+              "arguments" => %{}
+            })
+
+          GenServer.call(server, {:request, request, session_id, %{}})
+        end)
+
+      assert_receive {:deferred_registered, ref}, 1000
+
+      # Cancel the deferred reply
+      Hermes.Server.cancel_deferred(server, ref)
+
+      # The blocked caller should get an error
+      response = Task.await(task, 2000)
+      assert {:error, :cancelled} = response
+
+      # cancel_notify pid should receive notification
+      assert_receive {:deferred_cancelled, ^ref}, 1000
+
+      # Deferred entry should be cleaned up
+      state = :sys.get_state(server)
+      refute Map.has_key?(state.deferred_replies, ref)
+    end
+
+    test "second deferred_reply on same ref is a no-op", %{
+      server: server,
+      session_id: session_id
+    } do
+      task =
+        Task.async(fn ->
+          request = build_request("tools/call", %{"name" => "deferred_tool", "arguments" => %{}})
+          GenServer.call(server, {:request, request, session_id, %{}})
+        end)
+
+      assert_receive {:deferred_registered, ref}, 1000
+
+      # First resolve
+      result = %{"content" => [%{"type" => "text", "text" => "done"}], "isError" => false}
+      Hermes.Server.deferred_reply(server, ref, %{"result" => result})
+
+      # Wait for response
+      _response = Task.await(task, 2000)
+
+      # Second resolve should be a no-op (no crash)
+      Hermes.Server.deferred_reply(server, ref, %{"result" => result})
+
+      # Give it time to process
+      Process.sleep(50)
+
+      # Server should still be alive
+      assert Process.alive?(server)
+    end
+
+    test "second cancel on same ref is a no-op", %{
+      server: server,
+      session_id: session_id
+    } do
+      task =
+        Task.async(fn ->
+          request =
+            build_request("tools/call", %{
+              "name" => "deferred_tool_with_cancel",
+              "arguments" => %{}
+            })
+
+          GenServer.call(server, {:request, request, session_id, %{}})
+        end)
+
+      assert_receive {:deferred_registered, ref}, 1000
+
+      Hermes.Server.cancel_deferred(server, ref)
+
+      _response = Task.await(task, 2000)
+
+      # Second cancel should be a no-op
+      Hermes.Server.cancel_deferred(server, ref)
+      Process.sleep(50)
+      assert Process.alive?(server)
+    end
+
+    test "caller death triggers cleanup and cancel notification", %{
+      server: server,
+      session_id: session_id
+    } do
+      caller_pid =
+        spawn(fn ->
+          request =
+            build_request("tools/call", %{
+              "name" => "deferred_tool_with_cancel",
+              "arguments" => %{}
+            })
+
+          GenServer.call(server, {:request, request, session_id, %{}})
+        end)
+
+      # Wait for the deferred reply to be registered
+      assert_receive {:deferred_registered, ref}, 1000
+
+      # Verify it's tracked
+      state = :sys.get_state(server)
+      assert Map.has_key?(state.deferred_replies, ref)
+
+      # Kill the caller
+      Process.exit(caller_pid, :kill)
+
+      # Wait for DOWN to be processed
+      Process.sleep(100)
+
+      # cancel_notify should receive notification
+      assert_receive {:deferred_cancelled, ^ref}, 1000
+
+      # Deferred entry should be cleaned up
+      state = :sys.get_state(server)
+      refute Map.has_key?(state.deferred_replies, ref)
+    end
+
+    test "server_pid is available in frame private", %{
+      server: server,
+      session_id: session_id
+    } do
+      task =
+        Task.async(fn ->
+          request =
+            build_request("tools/call", %{
+              "name" => "deferred_tool_check_pid",
+              "arguments" => %{}
+            })
+
+          GenServer.call(server, {:request, request, session_id, %{}})
+        end)
+
+      assert_receive {:server_pid, received_pid}, 1000
+      assert received_pid == server
+
+      # Wait for deferred registration then clean up
+      assert_receive {:deferred_registered, ref}, 1000
+      Hermes.Server.deferred_reply(server, ref, %{"result" => %{}})
+      Task.await(task, 2000)
+    end
+  end
+
+  # Setup helper
+
+  defp deferred_server(_ctx) do
+    session_id = "test-session-#{System.unique_integer([:positive])}"
+    info = %{"name" => "TestClient", "version" => "1.0.0"}
+
+    start_supervised!(Hermes.Server.Registry)
+
+    start_supervised!(
+      {Session.Supervisor, server: DeferredStubServer, registry: Hermes.Server.Registry}
+    )
+
+    transport = start_supervised!(StubTransport)
+
+    server_opts = [
+      module: DeferredStubServer,
+      name: Hermes.Server.Registry.server(DeferredStubServer),
+      registry: Hermes.Server.Registry,
+      transport: [layer: StubTransport, name: transport]
+    ]
+
+    server = start_supervised!({Base, server_opts})
+
+    # Initialize the session
+    request = init_request(nil, info)
+    assert {:ok, _} = GenServer.call(server, {:request, request, session_id, %{}})
+    notification = build_notification("notifications/initialized", %{})
+    assert :ok = GenServer.cast(server, {:notification, notification, session_id, %{}})
+
+    Process.sleep(50)
+
+    # Register the test pid for the deferred server
+    DeferredStubServer.register_test_pid(self())
+
+    %{
+      transport: transport,
+      server: server,
+      session_id: session_id
+    }
+  end
+end

--- a/test/support/deferred_stub_server.ex
+++ b/test/support/deferred_stub_server.ex
@@ -1,0 +1,92 @@
+defmodule DeferredStubServer do
+  @moduledoc """
+  Test server that supports deferred tool call replies.
+
+  Tools:
+  - "deferred_tool" - defers, sends {:deferred_registered, ref} to registered test pid
+  - "deferred_tool_with_cancel" - same but includes cancel_notify option
+  - "deferred_tool_check_pid" - also sends {:server_pid, pid}
+
+  Before calling tools, register the test pid via:
+    DeferredStubServer.register_test_pid(self())
+  """
+
+  use Hermes.Server,
+    name: "Deferred Test Server",
+    version: "1.0.0",
+    capabilities: [:tools]
+
+  import Hermes.Server.Frame
+
+  alias Hermes.MCP.Error
+
+  # Simple process-based test pid registry using a named Agent
+  def register_test_pid(pid) do
+    case Process.whereis(:deferred_test_registry) do
+      nil ->
+        Agent.start_link(fn -> pid end, name: :deferred_test_registry)
+
+      _existing ->
+        Agent.update(:deferred_test_registry, fn _ -> pid end)
+    end
+
+    :ok
+  end
+
+  defp get_test_pid do
+    Agent.get(:deferred_test_registry, & &1)
+  end
+
+  @impl true
+  def init(_client_info, frame) do
+    frame =
+      frame
+      |> register_tool("deferred_tool",
+        description: "A tool that defers its reply",
+        input_schema: %{type: "object", properties: %{}}
+      )
+      |> register_tool("deferred_tool_with_cancel",
+        description: "A tool that defers with cancel notify",
+        input_schema: %{type: "object", properties: %{}}
+      )
+      |> register_tool("deferred_tool_check_pid",
+        description: "A tool that checks server_pid in frame",
+        input_schema: %{type: "object", properties: %{}}
+      )
+
+    {:ok, frame}
+  end
+
+  @impl true
+  def handle_tool_call("deferred_tool", _args, frame) do
+    ref = make_ref()
+    test_pid = get_test_pid()
+    send(test_pid, {:deferred_registered, ref})
+    {:defer, ref, %{}, frame}
+  end
+
+  def handle_tool_call("deferred_tool_with_cancel", _args, frame) do
+    ref = make_ref()
+    test_pid = get_test_pid()
+    send(test_pid, {:deferred_registered, ref})
+    {:defer, ref, %{cancel_notify: test_pid}, frame}
+  end
+
+  def handle_tool_call("deferred_tool_check_pid", _args, frame) do
+    ref = make_ref()
+    test_pid = get_test_pid()
+    server_pid = frame.private[:server_pid]
+    send(test_pid, {:server_pid, server_pid})
+    send(test_pid, {:deferred_registered, ref})
+    {:defer, ref, %{}, frame}
+  end
+
+  def handle_tool_call(name, _args, frame) do
+    {:error, Error.protocol(:invalid_request, %{message: "Unknown tool: #{name}"}), frame}
+  end
+
+  @impl true
+  def handle_notification(_notification, frame) do
+    {:noreply, frame}
+  end
+end


### PR DESCRIPTION
## Summary

- **Add deferred tool-call replies** — allow `handle_tool_call` to return `{:defer, ref, opts, frame}` instead of an immediate reply. The transport caller blocks naturally via `GenServer.call` until resolved via `Hermes.Server.deferred_reply/3` or cancelled via `Hermes.Server.cancel_deferred/2`.
- **Wire `notifications/cancelled` to deferred entries** — prevents the transport caller from blocking indefinitely when a client cancels a pending request.
- **Cherry-pick two upstream bugfixes** needed as prerequisites:
  - `fix(stdio)`: iterate over decoded messages list (#241)
  - `fix(tools)`: skip output schema validation on error responses (#225)

## Motivation

Long-running tool calls (file indexing, batch embedding, external API fan-out) can't return immediately. Today the only option is to block the handler process. Deferred replies let the server acknowledge the request, do async work, and resolve later — matching how real MCP servers need to operate.

This also enables cancellation: if the client sends `notifications/cancelled` for a deferred request, the server cleans up and unblocks the caller with `{:error, :cancelled}`.

## Changes

| File | What |
|---|---|
| `lib/hermes/server.ex` | Public API: `deferred_reply/3`, `cancel_deferred/2` |
| `lib/hermes/server/base.ex` | `deferred_replies` map in state, handle_cast for resolve/cancel, caller DOWN monitoring, session termination sweep, cancellation notification handling |
| `lib/hermes/server/handlers.ex` | Thread `{:defer, ...}` through `handle/3` |
| `lib/hermes/server/handlers/tools.ex` | Thread `{:defer, ...}` through `forward_to/3` |
| `lib/hermes/server/transport/stdio.ex` | Iterate decoded message list (cherry-pick #241) |
| `test/hermes/server/deferred_reply_test.exs` | 338-line test suite covering resolve, cancel, caller DOWN, session expiry |
| `test/support/deferred_stub_server.ex` | Test helper server |

## Test plan

- [x] Deferred reply resolves and unblocks caller
- [x] `notifications/cancelled` cancels deferred entry, caller gets `{:error, :cancelled}`
- [x] `cancel_notify` pid receives `{:deferred_cancelled, ref}` on cancellation
- [x] Caller DOWN cleans up deferred entry
- [x] Session termination sweeps all deferred replies
- [x] Error responses skip output schema validation