### PR TITLE
fix(transport): use :infinity timeout for async GenServer.call in StreamableHTTP

### DIFF
--- a/lib/hermes/server/transport/streamable_http.ex
+++ b/lib/hermes/server/transport/streamable_http.ex
@@ -157,7 +157,7 @@ defmodule Hermes.Server.Transport.StreamableHTTP do
   @spec handle_message(GenServer.server(), String.t(), map() | list(map), map()) ::
           {:ok, binary() | nil} | {:error, term()}
   def handle_message(transport, session_id, message, context) do
-    GenServer.call(transport, {:handle_message, session_id, message, context})
+    GenServer.call(transport, {:handle_message, session_id, message, context}, :infinity)
   end
 
   @doc """
@@ -171,7 +171,8 @@ defmodule Hermes.Server.Transport.StreamableHTTP do
   def handle_message_for_sse(transport, session_id, message, context) do
     GenServer.call(
       transport,
-      {:handle_message_for_sse, session_id, message, context}
+      {:handle_message_for_sse, session_id, message, context},
+      :infinity
     )
   end
 


### PR DESCRIPTION
## Summary

- `handle_message/4` and `handle_message_for_sse/4` dispatch work to async tasks via `Task.Supervisor` and reply later through `handle_info`. The `GenServer.call` that wraps them used the default 5000ms OTP timeout, which is shorter than the configured `request_timeout` (default 30s).
- This caused valid server responses to be discarded when tool execution exceeded 5 seconds — the caller got a timeout exit even though the server processed the request successfully.
- The actual request timeout is already enforced inside the Task via `forward_request_to_server/5,6`, so the outer `GenServer.call` timeout is redundant and should be `:infinity`.

## Reproduction

Any MCP tool that takes longer than 5 seconds to execute will cause the client to receive a timeout error, even though the server processes the request successfully and the response is ready.

```
** (exit) exited in: GenServer.call({:via, Registry, {Hermes.Server.Registry, {:transport, MyApp.MCP.Server, :streamable_http}}}, {:handle_message_for_sse, ...}, 5000)
    ** (EXIT) time out
```

## Changes

Two calls changed from `GenServer.call/2` to `GenServer.call/3` with `:infinity`:
- `handle_message/4` (line 160)
- `handle_message_for_sse/4` (line 171-176)

Other `GenServer.call` sites (`get_sse_handler`, `route_to_session`, `send_message`, `register_sse_handler`) are synchronous (`{:reply, ...}`) and correctly use the default timeout.

## Test plan

- [ ] Existing test suite passes (no behavioral change for requests under 5s)
- [ ] MCP tools that take >5s now return responses correctly instead of timing out

🤖 Generated with [Claude Code](https://claude.com/claude-code)