### PR TITLE
fix: cluster-safe session attach via pid + pluggable session supervisor

### DIFF
--- a/lib/hermes/server/base.ex
+++ b/lib/hermes/server/base.ex
@@ -115,19 +115,19 @@ defmodule Hermes.Server.Base do
       case handle_single_request(decoded, session, state) do
         {:reply, {:ok, %{"result" => result} = response}, new_state} ->
           request_id = response["id"]
-          if request_id, do: Session.complete_request(session.name, request_id)
+          if request_id, do: Session.complete_request(session.pid, request_id)
 
           {:reply, Message.encode_response(%{"result" => result}, response["id"]), new_state}
 
         {:reply, {:ok, %{"error" => error} = response}, new_state} ->
           request_id = response["id"]
-          if request_id, do: Session.complete_request(session.name, request_id)
+          if request_id, do: Session.complete_request(session.pid, request_id)
 
           {:reply, Message.encode_error(%{"error" => error}, response["id"]), new_state}
 
         {:reply, {:error, error}, new_state} ->
           request_id = decoded["id"]
-          if request_id, do: Session.complete_request(session.name, request_id)
+          if request_id, do: Session.complete_request(session.pid, request_id)
           {:reply, {:error, error}, new_state}
       end
     end
@@ -204,7 +204,7 @@ defmodule Hermes.Server.Base do
   def handle_info({:DOWN, ref, :process, _pid, reason}, state) do
     session_entry =
       Enum.find(state.sessions, fn
-        {_id, {_name, ^ref}} -> true
+        {_id, {_name, _pid, ^ref}} -> true
         _ -> false
       end)
 
@@ -343,7 +343,7 @@ defmodule Hermes.Server.Base do
 
   defp format_sessions(sessions) do
     sessions
-    |> Enum.map(fn {_id, {name, _}} -> Session.get(name) end)
+    |> Enum.map(fn {_id, {_name, pid, _ref}} -> Session.get(pid) end)
     |> Enum.reject(&is_nil/1)
   end
 
@@ -412,7 +412,7 @@ defmodule Hermes.Server.Base do
 
     :ok =
       Session.update_from_initialization(
-        session.name,
+        session.pid,
         protocol_version,
         client_info,
         client_capabilities
@@ -442,14 +442,14 @@ defmodule Hermes.Server.Base do
   defp handle_request(%{"id" => request_id, "method" => "logging/setLevel"} = request, session, state)
        when Server.is_supported_capability(state.capabilities, "logging") do
     level = request["params"]["level"]
-    :ok = Session.set_log_level(session.name, level)
+    :ok = Session.set_log_level(session.pid, level)
     {:reply, {:ok, Message.build_response(%{}, request_id)}, state}
   end
 
   defp handle_request(%{"id" => request_id, "method" => method} = request, session, state) do
     Logging.server_event("handling_request", %{id: request_id, method: method})
 
-    :ok = Session.track_request(session.name, request_id, method)
+    :ok = Session.track_request(session.pid, request_id, method)
 
     Telemetry.execute(
       Telemetry.event_server_request(),
@@ -471,7 +471,7 @@ defmodule Hermes.Server.Base do
 
   defp handle_notification(%{"method" => "notifications/initialized"}, session, %{module: module} = state) do
     Logging.server_event("client_initialized", %{session_id: session.id})
-    :ok = Session.mark_initialized(session.name)
+    :ok = Session.mark_initialized(session.pid)
 
     Logging.server_event("session_marked_initialized", %{
       session_id: session.id,
@@ -493,8 +493,8 @@ defmodule Hermes.Server.Base do
     request_id = params["requestId"]
     reason = Map.get(params, "reason", "cancelled")
 
-    if Session.has_pending_request?(session.name, request_id) do
-      request_info = Session.complete_request(session.name, request_id)
+    if Session.has_pending_request?(session.pid, request_id) do
+      request_info = Session.complete_request(session.pid, request_id)
 
       Logging.server_event("request_cancelled", %{
         session_id: session.id,
@@ -599,48 +599,40 @@ defmodule Hermes.Server.Base do
   @spec maybe_attach_session(session_id :: String.t(), map, t) ::
           {:ok, {session :: Session.t(), t}}
   defp maybe_attach_session(session_id, context, %{sessions: sessions} = state) when is_map_key(sessions, session_id) do
-    {session_name, _ref} = sessions[session_id]
-    session = Session.get(session_name)
+    {_session_name, pid, _ref} = sessions[session_id]
+    session = Session.get(pid)
     state = reset_session_expiry(session_id, state)
 
     {:ok, {session, %{state | frame: populate_frame(state.frame, session, context, state)}}}
   end
 
-  defp maybe_attach_session(session_id, context, %{sessions: sessions, registry: registry} = state) do
+  defp maybe_attach_session(session_id, context, %{sessions: _sessions, registry: registry} = state) do
     session_name = registry.server_session(state.module, session_id)
 
     case SessionSupervisor.create_session(registry, state.module, session_id) do
-      {:ok, pid} ->
-        ref = Process.monitor(pid)
-
-        state = %{
-          state
-          | sessions: Map.put(sessions, session_id, {session_name, ref})
-        }
-
-        state = reset_session_expiry(session_id, state)
-
-        session = Session.get(session_name)
-
-        {:ok, {session, %{state | frame: populate_frame(state.frame, session, context, state)}}}
-
-      {:error, {:already_started, pid}} ->
-        ref = Process.monitor(pid)
-
-        state = %{
-          state
-          | sessions: Map.put(sessions, session_id, {session_name, ref})
-        }
-
-        state = reset_session_expiry(session_id, state)
-
-        session = Session.get(session_name)
-
-        {:ok, {session, %{state | frame: populate_frame(state.frame, session, context, state)}}}
-
-      error ->
-        error
+      {:ok, pid} -> attach(pid, session_id, session_name, context, state)
+      {:error, {:already_started, pid}} -> attach(pid, session_id, session_name, context, state)
+      error -> error
     end
+  end
+
+  # Use the pid returned from create_session/start_link directly. Going
+  # through the registry's via tuple here would race with eventual
+  # consistency in distributed registries (e.g. Horde) where the
+  # registration may not yet be visible on this node even though the
+  # session pid is valid and reachable via Erlang distribution.
+  defp attach(pid, session_id, session_name, context, %{sessions: sessions} = state) do
+    ref = Process.monitor(pid)
+
+    state = %{
+      state
+      | sessions: Map.put(sessions, session_id, {session_name, pid, ref})
+    }
+
+    state = reset_session_expiry(session_id, state)
+    session = Session.get(pid)
+
+    {:ok, {session, %{state | frame: populate_frame(state.frame, session, context, state)}}}
   end
 
   defp populate_frame(frame, %Session{} = session, context, state) do
@@ -748,12 +740,12 @@ defmodule Hermes.Server.Base do
   defp validate_client_capability(%{frame: frame} = state, capability) do
     current_session = Frame.get_mcp_session_id(frame)
 
-    session_name =
-      Enum.find_value(state.sessions, fn {id, {name, _ref}} ->
-        if id == current_session, do: name
+    session_pid =
+      Enum.find_value(state.sessions, fn {id, {_name, pid, _ref}} ->
+        if id == current_session, do: pid
       end)
 
-    session = Session.get(session_name)
+    session = Session.get(session_pid)
 
     if Map.has_key?(session.client_capabilities || %{}, capability) do
       :ok

--- a/lib/hermes/server/session.ex
+++ b/lib/hermes/server/session.ex
@@ -7,6 +7,7 @@ defmodule Hermes.Server.Session do
           protocol_version: String.t() | nil,
           initialized: boolean(),
           name: GenServer.name() | nil,
+          pid: pid() | nil,
           client_info: map() | nil,
           client_capabilities: map() | nil,
           log_level: String.t(),
@@ -21,6 +22,7 @@ defmodule Hermes.Server.Session do
     :protocol_version,
     :log_level,
     :name,
+    :pid,
     initialized: false,
     client_info: nil,
     client_capabilities: nil,
@@ -35,7 +37,7 @@ defmodule Hermes.Server.Session do
     session_id = Keyword.fetch!(opts, :session_id)
     name = Keyword.fetch!(opts, :name)
 
-    Agent.start_link(fn -> new(id: session_id, name: name) end, name: name)
+    Agent.start_link(fn -> new(id: session_id, name: name, pid: self()) end, name: name)
   end
 
   @doc """

--- a/lib/hermes/server/session/supervisor.ex
+++ b/lib/hermes/server/session/supervisor.ex
@@ -39,7 +39,11 @@ defmodule Hermes.Server.Session.Supervisor do
     supervisor_opts = Keyword.get(opts, :supervisor_opts, [])
     name = registry.supervisor(@kind, server)
 
-    :persistent_term.put({__MODULE__, server}, supervisor_module)
+    # The supervisor `name` is unique per running instance (the registry
+    # adapter derives it from the server module + kind), so keying by
+    # `name` lets two instances of the same server module under different
+    # registries or supervisor modules coexist without colliding.
+    :persistent_term.put({__MODULE__, name}, supervisor_module)
 
     if supervisor_module == DynamicSupervisor do
       DynamicSupervisor.start_link(__MODULE__, server, name: name)
@@ -64,8 +68,8 @@ defmodule Hermes.Server.Session.Supervisor do
   same answer regardless of which node initiated the call.
   """
   def create_session(registry \\ Hermes.Server.Registry, server, session_id) do
-    supervisor_module = lookup_supervisor_module(server)
     name = registry.supervisor(@kind, server)
+    supervisor_module = lookup_supervisor_module(name)
     session_name = registry.server_session(server, session_id)
 
     supervisor_module.start_child(
@@ -78,8 +82,8 @@ defmodule Hermes.Server.Session.Supervisor do
   Terminates a session and cleans up its resources.
   """
   def close_session(registry \\ Hermes.Server.Registry, server, session_id) when is_binary(session_id) do
-    supervisor_module = lookup_supervisor_module(server)
     name = registry.supervisor(@kind, server)
+    supervisor_module = lookup_supervisor_module(name)
 
     if pid = registry.whereis_server_session(server, session_id) do
       supervisor_module.terminate_child(name, pid)

--- a/lib/hermes/server/session/supervisor.ex
+++ b/lib/hermes/server/session/supervisor.ex
@@ -10,51 +10,65 @@ defmodule Hermes.Server.Session.Supervisor do
   @doc """
   Starts the session supervisor.
 
-  ## Parameters
-    * `server` - The server module atom
-
-  ## Returns
-    * `{:ok, pid}` - Supervisor started successfully
-    * `{:error, reason}` - Failed to start supervisor
+  ## Options
+    * `:server` - The server module atom (required)
+    * `:registry` - Registry adapter (default: `Hermes.Server.Registry`)
+    * `:supervisor_module` - Underlying supervisor implementation. Defaults
+      to `DynamicSupervisor`. Pass `Horde.DynamicSupervisor` to make
+      session supervision cluster-wide so distributed clients (load
+      balanced across nodes) attach to the same session process.
+    * `:supervisor_opts` - Extra options forwarded to the supervisor
+      module's `start_link/1` (e.g. `[members: :auto]` for Horde).
 
   ## Examples
 
-      {:ok, _pid} = Session.Supervisor.start_link(MyServer)
+      # Default — single-node DynamicSupervisor
+      {:ok, _} = Session.Supervisor.start_link(server: MyServer)
+
+      # Cluster-wide via Horde
+      {:ok, _} = Session.Supervisor.start_link(
+        server: MyServer,
+        supervisor_module: Horde.DynamicSupervisor,
+        supervisor_opts: [members: :auto]
+      )
   """
   def start_link(opts \\ []) do
     server = Keyword.fetch!(opts, :server)
     registry = Keyword.get(opts, :registry, Hermes.Server.Registry)
+    supervisor_module = Keyword.get(opts, :supervisor_module, DynamicSupervisor)
+    supervisor_opts = Keyword.get(opts, :supervisor_opts, [])
     name = registry.supervisor(@kind, server)
-    DynamicSupervisor.start_link(__MODULE__, server, name: name)
+
+    :persistent_term.put({__MODULE__, server}, supervisor_module)
+
+    if supervisor_module == DynamicSupervisor do
+      DynamicSupervisor.start_link(__MODULE__, server, name: name)
+    else
+      supervisor_module.start_link(
+        Keyword.merge(
+          [name: name, strategy: :one_for_one],
+          supervisor_opts
+        )
+      )
+    end
   end
 
   @doc """
   Creates a new session for a client connection.
 
-  ## Parameters
-    * `registry` - The registry module to use to retrieve processes names
-    * `server` - The server module atom
-    * `session_id` - Unique identifier for the session (typically from transport)
-
-  ## Returns
-    * `{:ok, pid}` - Session created successfully
-    * `{:error, {:already_started, pid}}` - Session already exists
-    * `{:error, reason}` - Failed to create session
-
-  ## Examples
-
-      # Create a new session for a client
-      {:ok, session_pid} = Session.Supervisor.create_session(MyRegistry, MyServer, "session-123")
-
-      # Attempting to create duplicate session
-      {:error, {:already_started, ^session_pid}} = 
-        Session.Supervisor.create_session(MyRegistry, MyServer, "session-123")
+  When the supervisor was started with `:supervisor_module` set to a
+  cluster-wide implementation (e.g. `Horde.DynamicSupervisor`), the
+  start request is routed via consistent hashing to the single node
+  that owns the session. That node's start either succeeds (`{:ok, pid}`)
+  or returns `{:error, {:already_started, pid}}` — guaranteed to be the
+  same answer regardless of which node initiated the call.
   """
   def create_session(registry \\ Hermes.Server.Registry, server, session_id) do
+    supervisor_module = lookup_supervisor_module(server)
     name = registry.supervisor(@kind, server)
     session_name = registry.server_session(server, session_id)
 
-    DynamicSupervisor.start_child(
+    supervisor_module.start_child(
       name,
       {Session, session_id: session_id, name: session_name}
     )
@@ -62,29 +76,13 @@ defmodule Hermes.Server.Session.Supervisor do
 
   @doc """
   Terminates a session and cleans up its resources.
-
-  ## Parameters
-    * `registry` - The registry module to use to retrieve processes names
-    * `server` - The server module atom
-    * `session_id` - The session identifier to terminate
-
-  ## Returns
-    * `:ok` - Session terminated successfully
-    * `{:error, :not_found}` - Session does not exist
-
-  ## Examples
-
-      # Close an existing session
-      :ok = Session.Supervisor.close_session(MyRegistry, MyServer, "session-123")
-
-      # Attempting to close non-existent session
-      {:error, :not_found} = Session.Supervisor.close_session(MyRegistry, MyServer, "unknown")
   """
   def close_session(registry \\ Hermes.Server.Registry, server, session_id) when is_binary(session_id) do
+    supervisor_module = lookup_supervisor_module(server)
     name = registry.supervisor(@kind, server)
 
     if pid = registry.whereis_server_session(server, session_id) do
-      DynamicSupervisor.terminate_child(name, pid)
+      supervisor_module.terminate_child(name, pid)
     else
       {:error, :not_found}
     end
@@ -93,5 +91,9 @@ defmodule Hermes.Server.Session.Supervisor do
   @impl DynamicSupervisor
   def init(_init_arg) do
     DynamicSupervisor.init(strategy: :one_for_one)
+  end
+
+  defp lookup_supervisor_module(server) do
+    :persistent_term.get({__MODULE__, server}, DynamicSupervisor)
   end
 end

--- a/lib/hermes/server/supervisor.ex
+++ b/lib/hermes/server/supervisor.ex
@@ -95,9 +95,14 @@ defmodule Hermes.Server.Supervisor do
           task_supervisor: task_supervisor
         )
 
+      session_supervisor_opts =
+        [server: server, registry: registry]
+        |> maybe_put(opts, :session_supervisor_module, :supervisor_module)
+        |> maybe_put(opts, :session_supervisor_opts, :supervisor_opts)
+
       children = [
         {Task.Supervisor, name: task_supervisor},
-        {Session.Supervisor, server: server, registry: registry},
+        {Session.Supervisor, session_supervisor_opts},
         {Base, server_opts},
         {layer, transport_opts}
       ]
@@ -105,6 +110,13 @@ defmodule Hermes.Server.Supervisor do
       Supervisor.init(children, strategy: :one_for_all)
     else
       :ignore
+    end
+  end
+
+  defp maybe_put(target_opts, source_opts, source_key, target_key) do
+    case Keyword.fetch(source_opts, source_key) do
+      {:ok, value} -> Keyword.put(target_opts, target_key, value)
+      :error -> target_opts
     end
   end
 


### PR DESCRIPTION
## Problem

When a Hermes MCP server runs on multiple nodes behind a load balancer (e.g. libcluster + Horde, the setup the `Hermes.Server.Registry.Adapter` moduledoc explicitly suggests), session attach fails for follow-up requests on a node that didn't see `initialize`. Two layered issues make the documented Horde adapter path unusable on its own:

1. `Hermes.Server.Base.maybe_attach_session/3` calls `Session.get(session_name)` on every request, where `session_name` is the `{:via, registry, ...}` tuple. With Horde.Registry the registration is CRDT-replicated; the calling node may not see it yet on a follow-up request even though the session pid is alive and reachable via Erlang distribution. Result: `:noproc` exit and the session-owning `Hermes.Server.Base` GenServer crashes.

2. `Hermes.Server.Session.Supervisor` is hard-coded to `DynamicSupervisor`, so two nodes can each successfully `start_child` for the same `session_id` during the CRDT sync window — split-brain sessions, only one wins after CRDT resolution but the loser may have been the one that just received `notifications/initialized`.

Verified the bug in v0.14.1 with a 3-node Fly.io deployment and a 2-node local test cluster + Horde adapter: ~2/3 of cross-node requests fail with `Server not initialized`. Same issue reported in #141.

## Solution

Two minimal, additive changes:

1. **Use the pid returned from `create_session`/`start_link` directly.** `Session` gains a `:pid` field set via `self()` inside the `Agent.start_link` callback, so `session.pid` is available wherever `session.name` was used. All `Session.*` call sites in `Hermes.Server.Base` now pass the pid instead of the via tuple. With the default in-process `Registry` the behavior is unchanged (`Session.get(name)` and `Session.get(pid)` resolve to the same pid). With Horde the lookup is no longer racy because we don't do one — the pid travels with the session in the in-memory state map.

2. **Make the underlying session supervisor module pluggable.** `Hermes.Server.Session.Supervisor.start_link/1` accepts `:supervisor_module` (default `DynamicSupervisor`) and `:supervisor_opts`. Passing `Horde.DynamicSupervisor` makes session creation atomic across the cluster: consistent hashing routes `start_child` to a single owner node, so the second node receives `:already_started` with the remote pid instead of racing to spawn a duplicate. Top-level `Hermes.Server.Supervisor.start_link/2` forwards matching opts as `:session_supervisor_module` and `:session_supervisor_opts`.

## Rationale

These two changes are minimal and additive:

- Default behavior is unchanged (no new required config, no new deps).
- All 442 existing tests pass with no modifications.
- The pid lookup change is strictly better even single-node: it skips a registry round-trip on every request hot path.
- The pluggable supervisor preserves the `DynamicSupervisor` default for single-node users while unlocking cluster setups via the documented Horde path.

End-to-end verified with a 3-machine Fly.io production deployment + libcluster (DNSPoll) + Horde adapter. After deploy: `initialize`/`tools/list`/`tools/call` for the same `mcp-session-id` succeed regardless of which machine each request lands on, with no sleep, no CRDT sync wait, and no fly-replay/sticky-session workaround.

Closes #141.

```
BEGIN_COMMIT_OVERRIDE
fix: cluster-safe session attach via pid + pluggable session supervisor
END_COMMIT_OVERRIDE
```